### PR TITLE
style: differentiate assistant chat bubble color

### DIFF
--- a/components/ChatMessage.tsx
+++ b/components/ChatMessage.tsx
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 4,
   },
   assistantBubble: {
-    backgroundColor: Colors.light.tint,
+    backgroundColor: Colors.light.input,
     borderBottomLeftRadius: 4,
   },
   text: {


### PR DESCRIPTION
## Summary
- use contrasting `Colors.light.input` for assistant messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689102fefa4c83248ede148a467fa5ba