### PR TITLE
Refactor user service for typed inputs

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -38,10 +38,9 @@ const ForgotPassword = () => {
 
     try {
       const res = await resetPassword(email);
-      let respcontent = res.data.forgotPassword;
       setUserMsg({
         type: "success",
-        message: respcontent.data.message,
+        message: res.data.message,
       });
       setSubmitLoading(false);
     } catch (err) {

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -43,14 +43,14 @@ export default function LoginScreen() {
     try {
       const response = await loginUser(email, password);
       console.log("Login response:", response);
-      const { accessToken, refreshToken } = response.data.login.data;
+      const { accessToken, refreshToken } = response.data;
       console.log(
         "Login response:",
         accessToken,
         "====================================and==============================",
         refreshToken
       );
-      if (!accessToken || !refreshToken || !response.data.login.success) {
+      if (!accessToken || !refreshToken || !response.success) {
         setUserMsg({
           type: "error",
           message: "Login failed. Please try again.",

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -106,12 +106,12 @@ export default function SignupScreen() {
         gender,
         dob,
       });
-      const { accessToken, refreshToken } = response.data.registerUser.data;
+      const { accessToken, refreshToken } = response.data;
 
       if (
         !accessToken ||
         !refreshToken ||
-        !response.data.registerUser.success
+        !response.success
       ) {
         setUserMsg({
           type: "error",

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -1,47 +1,60 @@
 import { CREATE_USER, GET_VIEWER, LOGIN_USER, RESET_PASSWORD } from '../graphql/user';
 import { apolloClient as client } from '../utils/apollo';
+import { CreateUserInput } from '../types/user';
 
-
-export const createUser = async (input: any) => {
- return await client.mutate({
-    mutation: CREATE_USER,
-    variables: { input },
-  });
-
+export const createUser = async (input: CreateUserInput): Promise<any> => {
+  try {
+    const { data } = await client.mutate({
+      mutation: CREATE_USER,
+      variables: { input },
+    });
+    return data.registerUser;
+  } catch (error) {
+    throw new Error(
+      `Failed to create user: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 };
 
-export const loginUser = async (email: string, password: string) => {
- 
-  // try{
- return await client.mutate({
-    mutation: LOGIN_USER,
-    variables: {  email, password  },
-  });
-//   return data.login;
-// } catch (error) {
-//   throw new Error(JSON.stringify(error));
-// }
+export const loginUser = async (email: string, password: string): Promise<any> => {
+  try {
+    const { data } = await client.mutate({
+      mutation: LOGIN_USER,
+      variables: { email, password },
+    });
+    return data.login;
+  } catch (error) {
+    throw new Error(
+      `Failed to login: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 };
 
-
-export const getViewerProfile = async () => {
-  
-  return await client.query({
-    query: GET_VIEWER,
-    fetchPolicy: 'network-only',
-  });
-
-
+export const getViewerProfile = async (): Promise<any> => {
+  try {
+    const { data } = await client.query({
+      query: GET_VIEWER,
+      fetchPolicy: 'network-only',
+    });
+    return data.getUser;
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch viewer profile: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 };
 
-
-export const resetPassword = async (email: string) => {
+export const resetPassword = async (email: string): Promise<any> => {
   console.log('Resetting password for (from service):', email);
-
-  
- return await client.mutate({
-    mutation: RESET_PASSWORD,
-    variables: { email },
-  });
-
+  try {
+    const { data } = await client.mutate({
+      mutation: RESET_PASSWORD,
+      variables: { email },
+    });
+    return data.forgotPassword;
+  } catch (error) {
+    throw new Error(
+      `Failed to reset password: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 };

--- a/store/auth-store.ts
+++ b/store/auth-store.ts
@@ -40,8 +40,8 @@ export const useAuthStore = create<AuthState>()(
         await AsyncStorage.setItem('refreshToken', refreshToken);
 
         const userresonse = await getViewerProfile();
-        console.log('User response:',JSON.stringify(userresonse));
-        const user = userresonse.data.getUser.data;
+        console.log('User response:', JSON.stringify(userresonse));
+        const user = userresonse.data;
 
         if (!user) {
           throw new Error('Could not load your profile. Please try again.');
@@ -68,7 +68,7 @@ export const useAuthStore = create<AuthState>()(
           await AsyncStorage.setItem('accessToken', accessToken);
           await AsyncStorage.setItem('refreshToken', refreshToken);
           const userresonse = await getViewerProfile();
-          let user = userresonse.data.getUser.data
+          const user = userresonse.data
           console.log('User response:', user);
           if (!user || !accessToken || !refreshToken) {
             throw new Error('Login failed, Please try again later.');

--- a/types/user.ts
+++ b/types/user.ts
@@ -10,3 +10,14 @@ export interface LocalUser {
   createdAt: string
   updatedAt: string
 }
+
+export interface CreateUserInput {
+  email: string
+  password: string
+  name?: string
+  phoneNumber?: string
+  role?: string
+  aud?: string
+  gender?: string
+  dob?: Date
+}


### PR DESCRIPTION
## Summary
- add `CreateUserInput` interface for user creation
- refactor user service methods with explicit return types, error handling, and data returns
- update auth flows to consume new user service responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689102f77f408324b6e7c6fd1a2763f6