### PR TITLE
fix: handle login profile retrieval

### DIFF
--- a/store/auth-store.ts
+++ b/store/auth-store.ts
@@ -49,12 +49,10 @@ export const useAuthStore = create<AuthState>()(
         const userresonse = await getViewerProfile();
         console.log('User response:', JSON.stringify(userresonse));
 
-        const user = userresonse.data.getUser.data;
+        const user = userresonse.data;
 
-
-        if (!user) {
+        if (!userresonse.success || !user) {
           throw new Error('Could not load your profile. Please try again.');
-
         }
         if (!user.emailVerified) {
           throw new Error(


### PR DESCRIPTION
## Summary
- align login response parsing with updated getViewerProfile structure
- guard against failed profile fetch before completing login

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68917892ca5483249707a5693791b79b