### PR TITLE
feat: enable editing on confirmation

### DIFF
--- a/app/medication/confirmation.tsx
+++ b/app/medication/confirmation.tsx
@@ -1,22 +1,62 @@
-import React, { useEffect } from 'react';
-import { Text, View } from 'react-native';
-import { useMedicationStore } from '../../store/medication-store';
+import React, { useEffect, useState } from "react";
+import { Text, TextInput, View } from "react-native";
+import Button from "../../components/ui/Button";
+import { useMedicationStore } from "../../store/medication-store";
 
 const Confirmation = () => {
-    const { parsedMedication } = useMedicationStore();
+  const { parsedMedication, setParsedMedication } = useMedicationStore();
 
-    useEffect(() => {
-        console.log("🔍 Parsed Medication:", parsedMedication);
-    }, [parsedMedication]);
+  const [isEditing, setIsEditing] = useState(false);
+  const [name, setName] = useState(parsedMedication?.name || "");
+  const [dosage, setDosage] = useState(parsedMedication?.dosage || "");
+  const [instructions, setInstructions] = useState(
+    parsedMedication?.instructions || ""
+  );
+  const [therapy, setTherapy] = useState(parsedMedication?.therapy || "");
+
+  useEffect(() => {
+    console.log("🔍 Parsed Medication:", parsedMedication);
+    setName(parsedMedication?.name || "");
+    setDosage(parsedMedication?.dosage || "");
+    setInstructions(parsedMedication?.instructions || "");
+    setTherapy(parsedMedication?.therapy || "");
+  }, [parsedMedication]);
+
+  const handleSave = () => {
+    const updatedMedication = {
+      name,
+      dosage,
+      instructions,
+      therapy,
+    };
+
+    setParsedMedication(updatedMedication);
+    setIsEditing(false);
+  };
+
   return (
     <View>
       <Text>Confirmation</Text>
-      <Text>{parsedMedication?.name}</Text>
-      <Text>{parsedMedication?.dosage}</Text>
-      <Text>{parsedMedication?.instructions}</Text>
-      <Text>{parsedMedication?.therapy}</Text>
+      {isEditing ? (
+        <>
+          <TextInput value={name} onChangeText={setName} />
+          <TextInput value={dosage} onChangeText={setDosage} />
+          <TextInput value={instructions} onChangeText={setInstructions} />
+          <TextInput value={therapy} onChangeText={setTherapy} />
+          <Button title="Save" onPress={handleSave} />
+        </>
+      ) : (
+        <>
+          <Text>{name}</Text>
+          <Text>{dosage}</Text>
+          <Text>{instructions}</Text>
+          <Text>{therapy}</Text>
+          <Button title="Edit" onPress={() => setIsEditing(true)} />
+        </>
+      )}
     </View>
-  )
-}
+  );
+};
 
-export default Confirmation
+export default Confirmation;
+


### PR DESCRIPTION
## Summary
- add editing state and inputs on medication confirmation screen
- save edited values back to medication store

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68918cd098288324bfd3bb406bd0f1f4