### PR TITLE
feat: add theme-aware medication confirmation

### DIFF
--- a/app/medication/confirmation.tsx
+++ b/app/medication/confirmation.tsx
@@ -1,22 +1,36 @@
 import React, { useEffect } from 'react';
-import { Text, View } from 'react-native';
+import { SafeAreaView, Text, View } from 'react-native';
 import { useMedicationStore } from '../../store/medication-store';
 
 const Confirmation = () => {
-    const { parsedMedication } = useMedicationStore();
+  const { parsedMedication } = useMedicationStore();
 
-    useEffect(() => {
-        console.log("🔍 Parsed Medication:", parsedMedication);
-    }, [parsedMedication]);
+  useEffect(() => {
+    console.log('🔍 Parsed Medication:', parsedMedication);
+  }, [parsedMedication]);
+
+  if (!parsedMedication) {
+    return (
+      <SafeAreaView className="flex-1 items-center justify-center bg-white dark:bg-black">
+        <Text className="text-black dark:text-white">
+          No medication data available.
+        </Text>
+      </SafeAreaView>
+    );
+  }
+
   return (
-    <View>
-      <Text>Confirmation</Text>
-      <Text>{parsedMedication?.name}</Text>
-      <Text>{parsedMedication?.dosage}</Text>
-      <Text>{parsedMedication?.instructions}</Text>
-      <Text>{parsedMedication?.therapy}</Text>
-    </View>
-  )
-}
+    <SafeAreaView className="flex-1 bg-white dark:bg-black">
+      <View className="p-4">
+        <Text className="text-black dark:text-white">Confirmation</Text>
+        <Text className="text-black dark:text-white">{parsedMedication.name}</Text>
+        <Text className="text-black dark:text-white">{parsedMedication.dosage}</Text>
+        <Text className="text-black dark:text-white">{parsedMedication.instructions}</Text>
+        <Text className="text-black dark:text-white">{parsedMedication.therapy}</Text>
+      </View>
+    </SafeAreaView>
+  );
+};
 
-export default Confirmation
+export default Confirmation;
+


### PR DESCRIPTION
## Summary
- use SafeAreaView with theme-aware background for medication confirmation
- add fallback message when parsed medication is missing
- ensure text remains legible in light and dark themes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68918ce5c9788324aefe8150e8119f73