### PR TITLE
feat: update global styles and tailwind config

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,5 +1,6 @@
 import { Stack } from "expo-router";
 import { Colors } from "../../constants/Colors";
+import "../../global.css";
 
 export default function AuthLayout() {
   return (

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import { useColorScheme } from "@/hooks/useColorScheme";
 import { Tabs, useRouter } from "expo-router";
 import { Calendar, Home, MessageSquare, User } from "lucide-react-native";
 import { Colors } from "../../constants/Colors";
+import "../../global.css";
 
 export default function TabLayout() {
   const router = useRouter();

--- a/global.css
+++ b/global.css
@@ -1,3 +1,21 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system,
+      BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+      'Noto Sans', sans-serif;
+    --font-heading: 'Poppins', ui-sans-serif, system-ui, -apple-system,
+      BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+      'Noto Sans', sans-serif;
+    --line-height-base: 1.5;
+  }
+
+  body {
+    font-family: var(--font-sans);
+    line-height: var(--line-height-base);
+    @apply text-gray-900 bg-white antialiased;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,44 @@ module.exports = {
   content: ["./app/*.{js,jsx,ts,tsx}", "./components/*.{js,jsx,ts,tsx}", "./components/**/*.{js,jsx,ts,tsx}", "./app/**/*.{js,jsx,ts,tsx}", "./src/**/*.{js,jsx,ts,tsx}"],
   presets: [require("nativewind/preset")],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: [
+          'Inter',
+          'ui-sans-serif',
+          'system-ui',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          '"Segoe UI"',
+          'Roboto',
+          '"Helvetica Neue"',
+          'Arial',
+          '"Noto Sans"',
+          'sans-serif',
+        ],
+        heading: [
+          'Poppins',
+          'ui-sans-serif',
+          'system-ui',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          '"Segoe UI"',
+          'Roboto',
+          '"Helvetica Neue"',
+          'Arial',
+          '"Noto Sans"',
+          'sans-serif',
+        ],
+      },
+      lineHeight: {
+        base: '1.5',
+        heading: '1.25',
+      },
+      spacing: {
+        18: '4.5rem',
+        22: '5.5rem',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- define default fonts, line heights and base body styles in `global.css`
- extend `tailwind.config.js` with custom font families and spacing tokens
- import the global stylesheet in auth and tab layouts for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689193ecc3588324a4f99166187b4197