### PR TITLE
Add theme-aware color tokens for components

### DIFF
--- a/components/ChatMessage.tsx
+++ b/components/ChatMessage.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, View } from "react-native";
-import { Colors } from "../constants/Colors";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 interface ChatMessageProps {
   message: {
@@ -11,8 +12,10 @@ interface ChatMessageProps {
 }
 
 export default function ChatMessage({ message }: ChatMessageProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const isUser = message.role === "user";
-  
+
   return (
     <View style={[styles.container, isUser ? styles.userContainer : styles.assistantContainer]}>
       <View style={[styles.bubble, isUser ? styles.userBubble : styles.assistantBubble]}>
@@ -20,7 +23,7 @@ export default function ChatMessage({ message }: ChatMessageProps) {
           {message.content}
         </Text>
       </View>
-      
+
       <Text style={styles.timestamp}>
         {new Date(message.timestamp).toLocaleTimeString([], {
           hour: "2-digit",
@@ -31,42 +34,44 @@ export default function ChatMessage({ message }: ChatMessageProps) {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 16,
-    maxWidth: "80%",
-  },
-  userContainer: {
-    alignSelf: "flex-end",
-  },
-  assistantContainer: {
-    alignSelf: "flex-start",
-  },
-  bubble: {
-    borderRadius: 20,
-    padding: 12,
-    marginBottom: 4,
-  },
-  userBubble: {
-    backgroundColor: Colors.light.tint,
-    borderBottomRightRadius: 4,
-  },
-  assistantBubble: {
-    backgroundColor: Colors.light.input,
-    borderBottomLeftRadius: 4,
-  },
-  text: {
-    fontSize: 16,
-  },
-  userText: {
-    color: "#FFFFFF",
-  },
-  assistantText: {
-    color: Colors.light.text,
-  },
-  timestamp: {
-    fontSize: 12,
-    color: Colors.light.text,
-    alignSelf: "flex-end",
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      marginBottom: 16,
+      maxWidth: "80%",
+    },
+    userContainer: {
+      alignSelf: "flex-end",
+    },
+    assistantContainer: {
+      alignSelf: "flex-start",
+    },
+    bubble: {
+      borderRadius: 20,
+      padding: 12,
+      marginBottom: 4,
+    },
+    userBubble: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderBottomRightRadius: 4,
+    },
+    assistantBubble: {
+      backgroundColor: Colors[colorScheme].input,
+      borderBottomLeftRadius: 4,
+    },
+    text: {
+      fontSize: 16,
+    },
+    userText: {
+      color: Colors[colorScheme].foreground,
+    },
+    assistantText: {
+      color: Colors[colorScheme].text,
+    },
+    timestamp: {
+      fontSize: 12,
+      color: Colors[colorScheme].text,
+      alignSelf: "flex-end",
+    },
+  });
+}

--- a/components/DoseCard.tsx
+++ b/components/DoseCard.tsx
@@ -2,6 +2,7 @@ import { Colors } from "@/constants/Colors";
 import { MedicationDose } from "@/types/medication";
 import { Check, X } from "lucide-react-native";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 interface DoseCardProps {
   dose: MedicationDose;
@@ -10,10 +11,12 @@ interface DoseCardProps {
 }
 
 export default function DoseCard({ dose, onTake, onSkip }: DoseCardProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const isPending = !dose.status || dose.status === "pending";
   const isTaken = dose.status === "taken";
   const isSkipped = dose.status === "skipped" || dose.status === "missed";
-  
+
   // Format time (e.g., "09:00" to "9:00 AM")
   const formatTime = (time: string) => {
     const [hours, minutes] = time.split(":");
@@ -22,11 +25,11 @@ export default function DoseCard({ dose, onTake, onSkip }: DoseCardProps) {
     const formattedHour = hour % 12 || 12;
     return `${formattedHour}:${minutes} ${ampm}`;
   };
-  
+
   return (
     <View style={styles.container}>
       <View style={[styles.colorIndicator, { backgroundColor: dose.color }]} />
-      
+
       <View style={styles.contentContainer}>
         <View style={styles.header}>
           <Text style={styles.time}>{formatTime(dose.time)}</Text>
@@ -34,38 +37,38 @@ export default function DoseCard({ dose, onTake, onSkip }: DoseCardProps) {
             {isTaken ? "Taken" : isSkipped ? "Skipped" : "Pending"}
           </Text>
         </View>
-        
+
         <Text style={styles.name}>{dose.name}</Text>
         <Text style={styles.dosage}>{dose.dosage}</Text>
       </View>
-      
+
       {isPending && (
         <View style={styles.actionsContainer}>
           <TouchableOpacity
             style={[styles.actionButton, styles.takeButton]}
             onPress={() => onTake(dose.id)}
           >
-            <Check size={20} color="#FFFFFF" />
+            <Check size={20} color={Colors[colorScheme].foreground} />
           </TouchableOpacity>
-          
+
           <TouchableOpacity
             style={[styles.actionButton, styles.skipButton]}
             onPress={() => onSkip(dose.id)}
           >
-            <X size={20} color="#FFFFFF" />
+            <X size={20} color={Colors[colorScheme].foreground} />
           </TouchableOpacity>
         </View>
       )}
-      
+
       {(isTaken || isSkipped) && (
         <View style={styles.statusIndicator}>
           {isTaken ? (
             <View style={[styles.statusDot, styles.takenDot]}>
-              <Check size={12} color="#FFFFFF" />
+              <Check size={12} color={Colors[colorScheme].foreground} />
             </View>
           ) : (
             <View style={[styles.statusDot, styles.skippedDot]}>
-              <X size={12} color="#FFFFFF" />
+              <X size={12} color={Colors[colorScheme].foreground} />
             </View>
           )}
         </View>
@@ -74,87 +77,89 @@ export default function DoseCard({ dose, onTake, onSkip }: DoseCardProps) {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
-    backgroundColor: "#FFFFFF",
-    borderRadius: 16,
-    marginBottom: 12,
-    shadowColor:    "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 2,
-    overflow: "hidden",
-  },
-  colorIndicator: {
-    width: 6,
-    height: "100%",
-  },
-  contentContainer: {
-    flex: 1,
-    padding: 16,
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  time: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: Colors.light.text,
-  },
-  status: {
-    fontSize: 14,
-    color: Colors.light.text,
-  },
-  name: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: Colors.light.text,
-    marginBottom: 4,
-  },
-  dosage: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  actionsContainer: {
-    flexDirection: "column",
-    justifyContent: "center",
-    gap: 8,
-    padding: 12,
-  },
-  actionButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  takeButton: {
-    backgroundColor: Colors.light.tint,
-  },
-  skipButton: {
-    backgroundColor: Colors.light.tint,
-  },
-  statusIndicator: {
-    justifyContent: "center",
-    alignItems: "center",
-    paddingRight: 16,
-  },
-  statusDot: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  takenDot: {
-    backgroundColor: Colors.light.tint,
-  },
-  skippedDot: {
-    backgroundColor: Colors.light.tint,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      backgroundColor: Colors[colorScheme].card,
+      borderRadius: 16,
+      marginBottom: 12,
+      shadowColor: Colors[colorScheme].shadow,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 2,
+      overflow: "hidden",
+    },
+    colorIndicator: {
+      width: 6,
+      height: "100%",
+    },
+    contentContainer: {
+      flex: 1,
+      padding: 16,
+    },
+    header: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginBottom: 8,
+    },
+    time: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+    },
+    status: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+    },
+    name: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+      marginBottom: 4,
+    },
+    dosage: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    actionsContainer: {
+      flexDirection: "column",
+      justifyContent: "center",
+      gap: 8,
+      padding: 12,
+    },
+    actionButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    takeButton: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    skipButton: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    statusIndicator: {
+      justifyContent: "center",
+      alignItems: "center",
+      paddingRight: 16,
+    },
+    statusDot: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    takenDot: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    skippedDot: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+  });
+}

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -2,6 +2,7 @@ import { Colors } from "@/constants/Colors";
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 import Button from "./ui/Button";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 interface EmptyStateProps {
   icon?: React.ReactNode;
@@ -18,13 +19,15 @@ export default function EmptyState({
   buttonTitle,
   onButtonPress,
 }: EmptyStateProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   return (
     <View style={styles.container}>
       {icon && <View style={styles.iconContainer}>{icon}</View>}
-      
+
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.description}>{description}</Text>
-      
+
       {buttonTitle && onButtonPress && (
         <Button
           title={buttonTitle}
@@ -36,29 +39,31 @@ export default function EmptyState({
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 24,
-  },
-  iconContainer: {
-    marginBottom: 16,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: "700",
-    color: Colors.light.text,
-    textAlign: "center",
-    marginBottom: 8,
-  },
-  description: {
-    fontSize: 16,
-    color: Colors.light.text,
-    textAlign: "center",
-    marginBottom: 24,
-  },
-  button: {
-    minWidth: 200,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      alignItems: "center",
+      justifyContent: "center",
+      padding: 24,
+    },
+    iconContainer: {
+      marginBottom: 16,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      textAlign: "center",
+      marginBottom: 8,
+    },
+    description: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+      textAlign: "center",
+      marginBottom: 24,
+    },
+    button: {
+      minWidth: 200,
+    },
+  });
+}

--- a/components/MedicationCard.tsx
+++ b/components/MedicationCard.tsx
@@ -2,6 +2,7 @@ import { Colors } from "@/constants/Colors";
 import { Medication } from "@/types/medication";
 import { AlertCircle, Calendar, Clock, Pill } from "lucide-react-native";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 interface MedicationCardProps {
   medication: Medication;
@@ -9,10 +10,12 @@ interface MedicationCardProps {
 }
 
 export default function MedicationCard({ medication, onPress }: MedicationCardProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const isLowStock =
     typeof medication.remainingDoses === "number" &&
     medication.remainingDoses <= 7;
-  
+
   return (
     <TouchableOpacity
       style={styles.container}
@@ -20,33 +23,33 @@ export default function MedicationCard({ medication, onPress }: MedicationCardPr
       activeOpacity={0.7}
     >
       <View style={[styles.iconContainer, { backgroundColor: medication.color }]}>
-        <Pill size={24} color="#FFFFFF" />
+        <Pill size={24} color={Colors[colorScheme].foreground} />
       </View>
-      
+
       <View style={styles.contentContainer}>
         <View style={styles.header}>
           <Text style={styles.name}>{medication.name}</Text>
           <Text style={styles.dosage}>{medication.dosage}</Text>
         </View>
-        
+
         <View style={styles.details}>
           <View style={styles.detailItem}>
-            <Clock size={16} color={Colors.light.tint} />
+            <Clock size={16} color={Colors[colorScheme].tint} />
             <Text style={styles.detailText}>{medication.frequency}</Text>
           </View>
-          
+
           {medication.refillDate && (
             <View style={styles.detailItem}>
-              <Calendar size={16} color={Colors.light.tint} />
+              <Calendar size={16} color={Colors[colorScheme].tint} />
               <Text style={styles.detailText}>
                 Refill: {new Date(medication.refillDate).toLocaleDateString()}
               </Text>
             </View>
           )}
-          
+
           {isLowStock && (
             <View style={styles.warningContainer}>
-              <AlertCircle size={16} color={Colors.light.tint} />
+              <AlertCircle size={16} color={Colors[colorScheme].tint} />
               <Text style={styles.warningText}>
                 Low stock: {medication.remainingDoses} doses left
               </Text>
@@ -58,67 +61,69 @@ export default function MedicationCard({ medication, onPress }: MedicationCardPr
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
-    backgroundColor: Colors.light.background,
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 12,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  iconContainer: {
-    width: 48,
-    height: 48,
-    borderRadius: 12,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 16,
-  },
-  contentContainer: {
-    flex: 1,
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  name: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: Colors.light.text,
-  },
-  dosage: {
-    fontSize: 16,
-    fontWeight: "500",
-    color: Colors.light.text,
-  },
-  details: {
-    gap: 8,
-  },
-  detailItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  detailText: {
-    fontSize: 14,
-    color: Colors.light.text,
-  },
-  warningContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    marginTop: 4,
-  },
-  warningText: {
-    fontSize: 14,
-    color: Colors.light.text,
-    fontWeight: "500",
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      backgroundColor: Colors[colorScheme].background,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 12,
+      shadowColor: Colors[colorScheme].shadow,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 2,
+    },
+    iconContainer: {
+      width: 48,
+      height: 48,
+      borderRadius: 12,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: 16,
+    },
+    contentContainer: {
+      flex: 1,
+    },
+    header: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginBottom: 8,
+    },
+    name: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+    },
+    dosage: {
+      fontSize: 16,
+      fontWeight: "500",
+      color: Colors[colorScheme].text,
+    },
+    details: {
+      gap: 8,
+    },
+    detailItem: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+    },
+    detailText: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+    },
+    warningContainer: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+      marginTop: 4,
+    },
+    warningText: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+      fontWeight: "500",
+    },
+  });
+}

--- a/components/ProgressCircle.tsx
+++ b/components/ProgressCircle.tsx
@@ -1,6 +1,7 @@
 import { Colors } from "@/constants/Colors";
 import { StyleSheet, Text, View } from "react-native";
 import Svg, { Circle } from "react-native-svg";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 interface ProgressCircleProps {
   progress: number; // 0 to 100
@@ -17,6 +18,8 @@ export default function ProgressCircle({
   label,
   showPercentage = true,
 }: ProgressCircleProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   // Ensure progress is between 0 and 100
   const validProgress = Math.min(Math.max(progress, 0), 100);
   
@@ -33,7 +36,7 @@ export default function ProgressCircle({
           cx={size / 2}
           cy={size / 2}
           r={radius}
-          stroke={Colors.light.tint}
+          stroke={Colors[colorScheme].tint}
           strokeWidth={strokeWidth}
           fill="transparent"
         />
@@ -43,7 +46,7 @@ export default function ProgressCircle({
           cx={size / 2}
           cy={size / 2}
           r={radius}
-          stroke={Colors.light.tint}
+          stroke={Colors[colorScheme].tint}
           strokeWidth={strokeWidth}
           strokeDasharray={circumference}
           strokeDashoffset={strokeDashoffset}
@@ -63,25 +66,27 @@ export default function ProgressCircle({
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    position: "relative",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  textContainer: {
-    position: "absolute",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  percentageText: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: Colors.light.text,
-  },
-  labelText: {
-    fontSize: 14,
-    color: Colors.light.text,
-    marginTop: 4,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      position: "relative",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    textContainer: {
+      position: "absolute",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    percentageText: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+    },
+    labelText: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+      marginTop: 4,
+    },
+  });
+}

--- a/components/SectionHeader.tsx
+++ b/components/SectionHeader.tsx
@@ -1,6 +1,7 @@
 import { Colors } from "@/constants/Colors";
 import { ChevronRight } from "lucide-react-native";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 interface SectionHeaderProps {
   title: string;
@@ -8,41 +9,45 @@ interface SectionHeaderProps {
 }
 
 export default function SectionHeader({ title, onSeeAll }: SectionHeaderProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   return (
     <View style={styles.container}>
       <Text style={styles.title}>{title}</Text>
-      
+
       {onSeeAll && (
         <TouchableOpacity style={styles.seeAllButton} onPress={onSeeAll}>
           <Text style={styles.seeAllText}>See All</Text>
-          <ChevronRight size={16} color={Colors.light.tint} />
+          <ChevronRight size={16} color={Colors[colorScheme].tint} />
         </TouchableOpacity>
       )}
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 16,
-    paddingHorizontal: 4,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: "700",
-    color: Colors.light.text,
-  },
-  seeAllButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-  },
-  seeAllText: {
-    fontSize: 14,
-    fontWeight: "500",
-    color: Colors.light.tint,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginBottom: 16,
+      paddingHorizontal: 4,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+    },
+    seeAllButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 4,
+    },
+    seeAllText: {
+      fontSize: 14,
+      fontWeight: "500",
+      color: Colors[colorScheme].tint,
+    },
+  });
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -7,7 +7,8 @@ import {
     TouchableOpacity,
     ViewStyle,
 } from "react-native";
-import { Colors } from "../../constants/Colors";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 interface ButtonProps {
   title: string;
@@ -32,6 +33,8 @@ export default function Button({
   textStyle,
   icon,
 }: ButtonProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const getContainerStyle = () => {
     const variantStyle = {
       primary: styles.primaryContainer,
@@ -87,7 +90,11 @@ export default function Button({
     >
       {loading ? (
         <ActivityIndicator
-          color={variant === "primary" ? "#FFFFFF" : Colors.light.tint}
+          color={
+            variant === "primary"
+              ? Colors[colorScheme].foreground
+              : Colors[colorScheme].tint
+          }
           size="small"
         />
       ) : (
@@ -100,69 +107,71 @@ export default function Button({
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 12,
-    gap: 8,
-  },
-  primaryContainer: {
-    backgroundColor: Colors.light.tint,
-  },
-  secondaryContainer: {
-    backgroundColor: Colors.light.background,
-  },
-  outlineContainer: {
-    backgroundColor: "transparent",
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-  },
-  ghostContainer: {
-    backgroundColor: "transparent",
-  },
-  smallContainer: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-  },
-  mediumContainer: {
-    paddingVertical: 12,
-    paddingHorizontal: 24,
-  },
-  largeContainer: {
-    paddingVertical: 16,
-    paddingHorizontal: 32,
-  },
-  disabledContainer: {
-    opacity: 0.5,
-  },
-  text: {
-    fontWeight: "600",
-    textAlign: "center",
-  },
-  primaryText: {
-    color: "#FFFFFF",
-  },
-  secondaryText: {
-    color: Colors.light.text,
-  },
-  outlineText: {
-    color: Colors.light.tint,
-  },
-  ghostText: {
-    color: Colors.light.tint,
-  },
-  smallText: {
-    fontSize: 14,
-  },
-  mediumText: {
-    fontSize: 16,
-  },
-  largeText: {
-    fontSize: 18,
-  },
-  disabledText: {
-    opacity: 0.7,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: 12,
+      gap: 8,
+    },
+    primaryContainer: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    secondaryContainer: {
+      backgroundColor: Colors[colorScheme].background,
+    },
+    outlineContainer: {
+      backgroundColor: "transparent",
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+    },
+    ghostContainer: {
+      backgroundColor: "transparent",
+    },
+    smallContainer: {
+      paddingVertical: 8,
+      paddingHorizontal: 16,
+    },
+    mediumContainer: {
+      paddingVertical: 12,
+      paddingHorizontal: 24,
+    },
+    largeContainer: {
+      paddingVertical: 16,
+      paddingHorizontal: 32,
+    },
+    disabledContainer: {
+      opacity: 0.5,
+    },
+    text: {
+      fontWeight: "600",
+      textAlign: "center",
+    },
+    primaryText: {
+      color: Colors[colorScheme].foreground,
+    },
+    secondaryText: {
+      color: Colors[colorScheme].text,
+    },
+    outlineText: {
+      color: Colors[colorScheme].tint,
+    },
+    ghostText: {
+      color: Colors[colorScheme].tint,
+    },
+    smallText: {
+      fontSize: 14,
+    },
+    mediumText: {
+      fontSize: 16,
+    },
+    largeText: {
+      fontSize: 18,
+    },
+    disabledText: {
+      opacity: 0.7,
+    },
+  });
+}

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -5,6 +5,8 @@
 
 const tintColorLight = '#38bdf8';
 const tintColorDark = '#a1a1aa';
+const white = '#FFFFFF';
+const black = '#000000';
 
 export const Colors = {
   light: {
@@ -15,7 +17,9 @@ export const Colors = {
     tabIconDefault: '#687076',
     tabIconSelected: tintColorLight,
     input: 'rgba(186, 230, 253, 1)',
-
+    card: white,
+    foreground: white,
+    shadow: black,
   },
   dark: {
     text: '#ECEDEE',
@@ -25,5 +29,8 @@ export const Colors = {
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,
     input: 'rgba(12, 74, 110, 1)',
+    card: '#1e293b',
+    foreground: black,
+    shadow: black,
   },
 };


### PR DESCRIPTION
## Summary
- extend `Colors` with `card`, `foreground`, and `shadow` tokens
- apply `useColorScheme` across UI components to consume `Colors[colorScheme]`
- replace hard-coded hex values with theme tokens for dark mode support

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689193eaf4788324a464f0e1391c61cb