### PR TITLE
refactor: add semantic color tokens

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -209,7 +209,7 @@ const styles = StyleSheet.create({
     color: Colors.light.text,
   },
   section: {
-    backgroundColor: Colors.light.background,
+    backgroundColor: Colors.light.surface,
     borderRadius: 16,
     padding: 16,
     marginBottom: 24,

--- a/app/medication/[id].tsx
+++ b/app/medication/[id].tsx
@@ -217,7 +217,7 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: Colors.light.background,
+    backgroundColor: Colors.light.surface,
     borderRadius: 16,
     padding: 16,
     marginBottom: 16,
@@ -275,7 +275,7 @@ const styles = StyleSheet.create({
     color: Colors.light.tint,
   },
   detailsContainer: {
-    backgroundColor: Colors.light.background,
+    backgroundColor: Colors.light.surface,
     borderRadius: 16,
     padding: 16,
     marginBottom: 24,
@@ -322,7 +322,7 @@ const styles = StyleSheet.create({
     marginLeft: 12,
   },
   supplyContainer: {
-    backgroundColor: Colors.light.background,
+    backgroundColor: Colors.light.surface,
     borderRadius: 16,
     padding: 16,
     marginBottom: 24,

--- a/app/medication/add.tsx
+++ b/app/medication/add.tsx
@@ -40,7 +40,7 @@ export default function AddMedicationScreen() {
       frequency,
       time,
       instructions,
-      color: Colors.light.background,
+      color: Colors.light.primary,
       icon: selectedType.icon,
       quantity: quantity ? parseInt(quantity, 10) : undefined,
       remainingDoses: quantity ? parseInt(quantity, 10) : undefined,

--- a/app/medication/manually.tsx
+++ b/app/medication/manually.tsx
@@ -39,7 +39,7 @@ const Manually = () => {
       frequency,
       time,
       instructions,
-      color: Colors.light.background,
+      color: Colors.light.primary,
       icon: selectedType.icon,
       quantity: quantity ? parseInt(quantity, 10) : undefined,
       remainingDoses: quantity ? parseInt(quantity, 10) : undefined,

--- a/components/DoseCard.tsx
+++ b/components/DoseCard.tsx
@@ -77,7 +77,7 @@ export default function DoseCard({ dose, onTake, onSkip }: DoseCardProps) {
 const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
-    backgroundColor: "#FFFFFF",
+    backgroundColor: Colors.light.surface,
     borderRadius: 16,
     marginBottom: 12,
     shadowColor:    "#000",

--- a/components/MedicationCard.tsx
+++ b/components/MedicationCard.tsx
@@ -61,7 +61,7 @@ export default function MedicationCard({ medication, onPress }: MedicationCardPr
 const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
-    backgroundColor: Colors.light.background,
+    backgroundColor: Colors.light.surface,
     borderRadius: 16,
     padding: 16,
     marginBottom: 12,

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -112,7 +112,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.light.tint,
   },
   secondaryContainer: {
-    backgroundColor: Colors.light.background,
+    backgroundColor: Colors.light.surface,
   },
   outlineContainer: {
     backgroundColor: "transparent",

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,27 +3,32 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#38bdf8';
-const tintColorDark = '#a1a1aa';
+const primaryColorLight = '#38bdf8';
+const primaryColorDark = '#38bdf8';
 
 export const Colors = {
   light: {
-    text: '#0c4a6e',
-    background: 'rgba(8, 145, 178, 1)',
-    tint: tintColorLight,
+    text: '#0f172a',
+    background: '#f1f5f9',
+    surface: '#ffffff',
+    primary: primaryColorLight,
+    secondary: '#64748b',
+    tint: primaryColorLight,
     icon: '#687076',
     tabIconDefault: '#687076',
-    tabIconSelected: tintColorLight,
-    input: 'rgba(186, 230, 253, 1)',
-
+    tabIconSelected: primaryColorLight,
+    input: '#e2e8f0',
   },
   dark: {
-    text: '#ECEDEE',
-    background: 'rgba(8, 51, 68, 1)',
-    tint: tintColorDark,
+    text: '#f8fafc',
+    background: '#0f172a',
+    surface: '#1e293b',
+    primary: primaryColorDark,
+    secondary: '#94a3b8',
+    tint: primaryColorDark,
     icon: '#9BA1A6',
     tabIconDefault: '#9BA1A6',
-    tabIconSelected: tintColorDark,
-    input: 'rgba(12, 74, 110, 1)',
+    tabIconSelected: primaryColorDark,
+    input: '#1e293b',
   },
 };


### PR DESCRIPTION
## Summary
- introduce semantic colors with neutral background/surface and primary/secondary tokens
- use new surface token across cards, buttons, and profile/medication details
- default new medications to use primary accent color

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689193e2d108832481d000413393b0ef