### PR TITLE
feat: enable theme-aware colors

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -12,26 +12,18 @@ import "../../global.css";
 
 export default function TabLayout() {
   const router = useRouter();
-  const colorScheme = useColorScheme();
-
-  const bgcolor =
-    colorScheme === "light" ? Colors.light.background : Colors.dark.background;
-  const textcolor =
-    colorScheme === "light" ? Colors.light.text : Colors.dark.text;
-
-    const tintcolor =
-    colorScheme === "light" ? Colors.light.tint : Colors.dark.tint;
+  const colorScheme = useColorScheme() ?? "light";
   
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <Tabs
         screenOptions={{
-          tabBarActiveTintColor: tintcolor,
-          tabBarInactiveTintColor: textcolor,
+          tabBarActiveTintColor: Colors[colorScheme].tint,
+          tabBarInactiveTintColor: Colors[colorScheme].text,
           tabBarStyle: {
-            backgroundColor: bgcolor,
+            backgroundColor: Colors[colorScheme].background,
             borderTopWidth: 1,
-            borderTopColor: tintcolor,
+            borderTopColor: Colors[colorScheme].tint,
             elevation: 0,
             height: sizes.lg,
             paddingBottom: spacing.sm,
@@ -41,8 +33,7 @@ export default function TabLayout() {
             fontWeight: "500",
           },
           headerStyle: {
-            backgroundColor: bgcolor,
-
+            backgroundColor: Colors[colorScheme].background,
           },
           headerShadowVisible: true,
           headerTitleStyle: {
@@ -50,7 +41,7 @@ export default function TabLayout() {
             fontSize: 24,
           },
           headerTitleAlign: "center",
-          headerTintColor: textcolor,
+          headerTintColor: Colors[colorScheme].text,
 
         }}
       >

--- a/app/(tabs)/assistant.tsx
+++ b/app/(tabs)/assistant.tsx
@@ -10,11 +10,14 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import ChatMessage from "../../components/ChatMessage";
 import { Colors } from "../../constants/Colors";
 import { useAIAssistantStore } from "../../store/ai-assistant-store";
 
 export default function AssistantScreen() {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const [question, setQuestion] = useState("");
   const flatListRef = useRef<FlatList>(null);
   
@@ -77,7 +80,7 @@ export default function AssistantScreen() {
           onPress={handleSendQuestion}
           disabled={!question.trim() || isLoading}
         >
-          <Send size={20} color="#FFFFFF" />
+          <Send size={20} color={Colors[colorScheme].foreground} />
         </TouchableOpacity>
       </View>
       
@@ -90,85 +93,87 @@ export default function AssistantScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.light.background,
-  },
-  header: {
-    padding: 16,
-    backgroundColor: Colors.light.background,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.light.text,
-  },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: Colors.light.text,
-    marginBottom: 4,
-  },
-  headerSubtitle: {
-    fontSize: 14,
-    color:  Colors.light.text,
-  },
-  messagesList: {
-    flex: 1,
-  },
-  messagesContent: {
-    padding: 16,
-    paddingTop: 8,
-  },
-  inputContainer: {
-    flexDirection: "row",
-    padding: 12,
-    backgroundColor: Colors.light.background,
-    borderTopWidth: 1,
-    borderTopColor: Colors.light.text,
-    alignItems: "flex-end",
-  },
-  input: {
-    flex: 1,
-    backgroundColor: Colors.light.tint,
-    borderRadius: 20,
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    paddingRight: 48,
-    maxHeight: 120,
-    fontSize: 16,
-  },
-  sendButton: {
-    position: "absolute",
-    right: 20,
-    bottom: 20,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: Colors.light.tint,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  disabledSendButton: {
-    opacity: 0.5,
-  },
-  loadingContainer: {
-    position: "absolute",
-    bottom: 80,
-    left: 0,
-    right: 0,
-    alignItems: "center",
-    padding: 8,
-  },
-  loadingText: {
-    backgroundColor: Colors.light.tint,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 16,
-    fontSize: 14,
-    color: "#FFFFFF",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    header: {
+      padding: 16,
+      backgroundColor: Colors[colorScheme].background,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].text,
+    },
+    headerTitle: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      marginBottom: 4,
+    },
+    headerSubtitle: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+    },
+    messagesList: {
+      flex: 1,
+    },
+    messagesContent: {
+      padding: 16,
+      paddingTop: 8,
+    },
+    inputContainer: {
+      flexDirection: "row",
+      padding: 12,
+      backgroundColor: Colors[colorScheme].background,
+      borderTopWidth: 1,
+      borderTopColor: Colors[colorScheme].text,
+      alignItems: "flex-end",
+    },
+    input: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 20,
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      paddingRight: 48,
+      maxHeight: 120,
+      fontSize: 16,
+    },
+    sendButton: {
+      position: "absolute",
+      right: 20,
+      bottom: 20,
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: Colors[colorScheme].tint,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    disabledSendButton: {
+      opacity: 0.5,
+    },
+    loadingContainer: {
+      position: "absolute",
+      bottom: 80,
+      left: 0,
+      right: 0,
+      alignItems: "center",
+      padding: 8,
+    },
+    loadingText: {
+      backgroundColor: Colors[colorScheme].tint,
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      borderRadius: 16,
+      fontSize: 14,
+      color: Colors[colorScheme].foreground,
+      shadowColor: "#000",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 2,
+    },
+  });
+}

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -5,9 +5,12 @@ import { useMedicationStore } from "@/store/medication-store";
 import { ChevronLeft, ChevronRight } from "lucide-react-native";
 import { useState } from "react";
 import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import { spacing } from "../../constants/Theme";
 
 export default function CalendarScreen() {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [currentMonth, setCurrentMonth] = useState(new Date());
   
@@ -96,13 +99,13 @@ export default function CalendarScreen() {
       {/* Calendar header */}
       <View style={styles.calendarHeader}>
         <TouchableOpacity onPress={goToPreviousMonth}>
-          <ChevronLeft size={24} color={Colors.light.tint} />
+          <ChevronLeft size={24} color={Colors[colorScheme].tint} />
         </TouchableOpacity>
         
         <Text style={styles.monthYearText}>{formatMonthYear(currentMonth)}</Text>
         
         <TouchableOpacity onPress={goToNextMonth}>
-          <ChevronRight size={24} color={Colors.light.text} />
+          <ChevronRight size={24} color={Colors[colorScheme].text} />
         </TouchableOpacity>
       </View>
       
@@ -176,86 +179,88 @@ export default function CalendarScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.light.background,
-  },
-  calendarHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingHorizontal: spacing.md,
-    paddingVertical: 12,
-    backgroundColor: Colors.light.background,
-  },
-  monthYearText: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: Colors.light.text,
-  },
-  weekdayHeader: {
-    flexDirection: "row",
-    backgroundColor: Colors.light.background,
-    paddingBottom: spacing.sm,
-  },
-  weekdayText: {
-    flex: 1,
-    textAlign: "center",
-    fontSize: 14,
-    fontWeight: "500",
-    color:  Colors.light.text,
-  },
-  calendarGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    backgroundColor:    Colors.light.background,
-    paddingBottom: spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor:  Colors.light.tint,
-  },
-  dayContainer: {
-    width: "14.28%",
-    aspectRatio: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: spacing.xs,
-  },
-  selectedDayContainer: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 20,
-  },
-  todayContainer: {
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-    borderRadius: 20,
-  },
-  dayText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  selectedDayText: {
-    color: "#FFFFFF",
-    fontWeight: "600",
-  },
-  todayText: {
-    color: Colors.light.tint,
-    fontWeight: "600",
-  },
-  selectedDateHeader: {
-    padding: spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.light.tint,
-  },
-  selectedDateText: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: Colors.light.text,
-  },
-  dosesContainer: {
-    flex: 1,
-  },
-  dosesContent: {
-    padding: spacing.md,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    calendarHeader: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      paddingHorizontal: spacing.md,
+      paddingVertical: 12,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    monthYearText: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+    },
+    weekdayHeader: {
+      flexDirection: "row",
+      backgroundColor: Colors[colorScheme].background,
+      paddingBottom: spacing.sm,
+    },
+    weekdayText: {
+      flex: 1,
+      textAlign: "center",
+      fontSize: 14,
+      fontWeight: "500",
+      color: Colors[colorScheme].text,
+    },
+    calendarGrid: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      backgroundColor: Colors[colorScheme].background,
+      paddingBottom: spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].tint,
+    },
+    dayContainer: {
+      width: "14.28%",
+      aspectRatio: 1,
+      justifyContent: "center",
+      alignItems: "center",
+      padding: spacing.xs,
+    },
+    selectedDayContainer: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 20,
+    },
+    todayContainer: {
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+      borderRadius: 20,
+    },
+    dayText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    selectedDayText: {
+      color: Colors[colorScheme].foreground,
+      fontWeight: "600",
+    },
+    todayText: {
+      color: Colors[colorScheme].tint,
+      fontWeight: "600",
+    },
+    selectedDateHeader: {
+      padding: spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].tint,
+    },
+    selectedDateText: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+    },
+    dosesContainer: {
+      flex: 1,
+    },
+    dosesContent: {
+      padding: spacing.md,
+    },
+  });
+}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,7 +2,8 @@ import { Medication } from "@/types/medication";
 import { useRouter } from "expo-router";
 import { Bell, Pill, Plus } from "lucide-react-native";
 import { useEffect } from "react";
-import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, useColorScheme, View } from "react-native";
+import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import { Avatar } from 'react-native-paper';
 import DoseCard from "../../components/DoseCard";
 import EmptyState from "../../components/EmptyState";
@@ -14,7 +15,8 @@ import { spacing, sizes } from "../../constants/Theme";
 import { useAuthStore } from "../../store/auth-store";
 import { useMedicationStore } from "../../store/medication-store";
 export default function DashboardScreen() {
- const colorScheme = useColorScheme();
+ const colorScheme = useColorScheme() ?? "light";
+ const styles = createStyles(colorScheme);
   const router = useRouter();
   const { user } = useAuthStore();
   const {
@@ -28,10 +30,7 @@ export default function DashboardScreen() {
     refreshUpcomingDoses,
     calculateAdherenceRate,
   } = useMedicationStore();
-     const textcolor =
-    colorScheme === "light" ? Colors.light.text : Colors.dark.text;
-    const localbagroundcolor =
-    colorScheme === "light" ? "#f1f5f9" : "#020617";
+ const textcolor = Colors[colorScheme].text;
   useEffect(() => {
     refreshUpcomingDoses();
     calculateAdherenceRate();
@@ -65,7 +64,7 @@ const handleMedicationPress = (medication: Medication) => {
   
   return (
     <SafeAreaView style={{ flex: 1 }}>
-    <ScrollView style={[styles.container, { backgroundColor: localbagroundcolor }]} contentContainerStyle={styles.content}>
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <View style={styles.statsContainer} >
         <Avatar.Text
           size={24}
@@ -116,7 +115,7 @@ const handleMedicationPress = (medication: Medication) => {
         ))
       ) : (
         <EmptyState
-          icon={<Bell size={48} color={Colors.light.text} />}
+          icon={<Bell size={48} color={Colors[colorScheme].text} />}
           title="No Pending Doses"
           description="You have no pending doses for today. Great job staying on track!"
         />
@@ -138,7 +137,7 @@ const handleMedicationPress = (medication: Medication) => {
         ))
       ) : (
         <EmptyState
-          icon={<Pill size={48} color={Colors.light.text} />}
+          icon={<Pill size={48} color={Colors[colorScheme].text} />}
           title="No Medications"
           description="You haven't added any medications yet. Tap the button below to add your first medication."
           buttonTitle="Add Medication"
@@ -154,73 +153,71 @@ const handleMedicationPress = (medication: Medication) => {
         onPress={handleAddMedication}
         activeOpacity={0.8}
       >
-        <Plus size={sizes.sm} color="#FFFFFF" />
+        <Plus size={sizes.sm} color={Colors[colorScheme].foreground} />
       </TouchableOpacity>
     </SafeAreaView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  content: {
-    padding: spacing.md,
-    paddingBottom: 100, // Extra padding at bottom for FAB
-  },
-  statsContainer: {
-    flexDirection: "row",
-    backgroundColor: "rgba(224, 242, 254, .5)",
-    borderRadius: spacing.md,
-    padding: spacing.md,
-    marginBottom: spacing.lg,
-    alignItems: "center",
-    // shadowOffset: { width: 0, height: 2 },
-    // shadowOpacity: 0.1,
-    // shadowRadius: 8,
-    elevation: 2,
-  },
-  statsDetails: {
-    flex: 1,
-    flexDirection: "row",
-    marginLeft: 16,
-    height: 80,
-    alignItems: "center",
-    justifyContent: "space-around",
-  },
-  statItem: {
-    alignItems: "center",
-  },
-  statValue: {
-    fontSize: 24,
-    fontWeight: "700",
- 
-  },
-  statLabel: {
-    fontSize: 14,
-
-    marginTop: 4,
-  },
-  statDivider: {
-    width: 1,
-    height: "50%",
-    backgroundColor: Colors.light.icon,
-  },
-  addButton: {
-    position: "absolute",
-    bottom: spacing.lg,
-    right: spacing.lg,
-    width: sizes.lg,
-    height: sizes.lg,
-    borderRadius: sizes.lg / 2,
-    backgroundColor: Colors.light.tint,
-    justifyContent: "center",
-    alignItems: "center",
-    shadowColor: Colors.light.tint,
-    shadowOffset: { width: 0, height: spacing.xs },
-    shadowOpacity: 0.3,
-    shadowRadius: spacing.sm,
-    elevation: 5,
-    zIndex: 1000,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    content: {
+      padding: spacing.md,
+      paddingBottom: 100, // Extra padding at bottom for FAB
+    },
+    statsContainer: {
+      flexDirection: "row",
+      backgroundColor: "rgba(224, 242, 254, .5)",
+      borderRadius: spacing.md,
+      padding: spacing.md,
+      marginBottom: spacing.lg,
+      alignItems: "center",
+      elevation: 2,
+    },
+    statsDetails: {
+      flex: 1,
+      flexDirection: "row",
+      marginLeft: 16,
+      height: 80,
+      alignItems: "center",
+      justifyContent: "space-around",
+    },
+    statItem: {
+      alignItems: "center",
+    },
+    statValue: {
+      fontSize: 24,
+      fontWeight: "700",
+    },
+    statLabel: {
+      fontSize: 14,
+      marginTop: 4,
+    },
+    statDivider: {
+      width: 1,
+      height: "50%",
+      backgroundColor: Colors[colorScheme].icon,
+    },
+    addButton: {
+      position: "absolute",
+      bottom: spacing.lg,
+      right: spacing.lg,
+      width: sizes.lg,
+      height: sizes.lg,
+      borderRadius: sizes.lg / 2,
+      backgroundColor: Colors[colorScheme].tint,
+      justifyContent: "center",
+      alignItems: "center",
+      shadowColor: Colors[colorScheme].tint,
+      shadowOffset: { width: 0, height: spacing.xs },
+      shadowOpacity: 0.3,
+      shadowRadius: spacing.sm,
+      elevation: 5,
+      zIndex: 1000,
+    },
+  });
+}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -3,10 +3,13 @@ import { useRouter } from 'expo-router';
 import { Bell, Clock, HelpCircle, LogOut, Moon, Shield } from "lucide-react-native";
 import React from "react";
 import { Alert, SafeAreaView, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import { useAuthStore } from "../../store/auth-store";
 import { spacing, sizes } from "../../constants/Theme";
 
 export default function ProfileScreen() {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const [notifications, setNotifications] = React.useState(true);
   const [darkMode, setDarkMode] = React.useState(false);
   const { user, logout } = useAuthStore();
@@ -66,7 +69,7 @@ export default function ProfileScreen() {
         
         <View style={styles.settingItem}>
           <View style={styles.settingIconContainer}>
-            <Bell size={20} color={Colors.light.tint} />
+            <Bell size={20} color={Colors[colorScheme].tint} />
           </View>
           
           <View style={styles.settingContent}>
@@ -79,14 +82,14 @@ export default function ProfileScreen() {
           <Switch
             value={notifications}
             onValueChange={setNotifications}
-            trackColor={{ false: Colors.light.tint, true: Colors.light.text }}
-            thumbColor="#FFFFFF"
+            trackColor={{ false: Colors[colorScheme].tint, true: Colors[colorScheme].text }}
+            thumbColor={Colors[colorScheme].foreground}
           />
         </View>
         
         <View style={styles.settingItem}>
           <View style={styles.settingIconContainer}>
-            <Clock size={20} color={Colors.light.tint} />
+            <Clock size={20} color={Colors[colorScheme].tint} />
           </View>
           
           <View style={styles.settingContent}>
@@ -103,7 +106,7 @@ export default function ProfileScreen() {
         
         <View style={styles.settingItem}>
           <View style={styles.settingIconContainer}>
-            <Moon size={20} color={Colors.light.tint} />
+            <Moon size={20} color={Colors[colorScheme].tint} />
           </View>
           
           <View style={styles.settingContent}>
@@ -116,8 +119,8 @@ export default function ProfileScreen() {
           <Switch
             value={darkMode}
             onValueChange={setDarkMode}
-            trackColor={{ false: Colors.light.tint, true: Colors.light.text }}
-            thumbColor="#FFFFFF"
+            trackColor={{ false: Colors[colorScheme].tint, true: Colors[colorScheme].text }}
+            thumbColor={Colors[colorScheme].foreground}
           />
         </View>
       </View>
@@ -127,7 +130,7 @@ export default function ProfileScreen() {
         
         <TouchableOpacity style={styles.settingItem}>
           <View style={styles.settingIconContainer}>
-            <HelpCircle size={20} color={Colors.light.tint} />
+            <HelpCircle size={20} color={Colors[colorScheme].tint} />
           </View>
           
           <View style={styles.settingContent}>
@@ -140,7 +143,7 @@ export default function ProfileScreen() {
         
         <TouchableOpacity style={styles.settingItem}>
           <View style={styles.settingIconContainer}>
-            <Shield size={20} color={Colors.light.tint} />
+            <Shield size={20} color={Colors[colorScheme].tint} />
           </View>
           
           <View style={styles.settingContent}>
@@ -153,7 +156,7 @@ export default function ProfileScreen() {
       </View>
       
       <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
-        <LogOut size={20} color={Colors.light.tint} />
+        <LogOut size={20} color={Colors[colorScheme].tint} />
         <Text style={styles.logoutText}>Log Out</Text>
       </TouchableOpacity>
       
@@ -163,125 +166,126 @@ export default function ProfileScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.light.background,
-  },
-  content: {
-    padding: spacing.md,
-  },
-  profileHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: Colors.light.icon,
-    borderRadius: spacing.md,
-    padding: spacing.md,
-    marginBottom: spacing.lg,
-    shadowColor: Colors.light.tint,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: spacing.sm,
-    elevation: 2,
-  },
-  avatarContainer: {
-    width: sizes.lg,
-    height: sizes.lg,
-    borderRadius: sizes.lg / 2,
-    backgroundColor: Colors.light.tint,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: spacing.md,
-  },
-  avatarText: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: "#FFFFFF",
-  },
-  profileInfo: {
-    flex: 1,
-  },
-  profileName: {
-    fontSize: 20,
-    fontWeight: "700",
-    color: Colors.light.text,
-    marginBottom: spacing.xs,
-  },
-  profileEmail: {
-    fontSize: 14,
-    color: Colors.light.text,
-  },
-  section: {
-    backgroundColor: Colors.light.surface,
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 24,
-
-    shadowColor: Colors.light.tint,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: spacing.sm,
-    elevation: 2,
-  },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: Colors.light.text,
-    marginBottom: spacing.md,
-  },
-  settingItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.light.icon,
-  },
-  settingIconContainer: {
-    width: sizes.md,
-    height: sizes.md,
-    borderRadius: sizes.md / 2,
-    backgroundColor: `${Colors.light.tint}20`,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: spacing.md,
-  },
-  settingContent: {
-    flex: 1,
-  },
-  settingTitle: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: Colors.light.text,
-    marginBottom: 2,
-  },
-  settingDescription: {
-    fontSize: 14,
-    color: Colors.light.text,
-  },
-  settingAction: {
-    fontSize: 14,
-    fontWeight: "500",
-    color: Colors.light.tint,
-  },
-  logoutButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#FFF1F0",
-    borderRadius: 12,
-    padding: spacing.md,
-    marginBottom: spacing.lg,
-  },
-  logoutText: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: Colors.light.tint,
-    marginLeft: spacing.sm,
-  },
-  versionText: {
-    textAlign: "center",
-    fontSize: 14,
-    color: Colors.light.text,
-    marginBottom: spacing.lg,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    content: {
+      padding: spacing.md,
+    },
+    profileHeader: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: Colors[colorScheme].icon,
+      borderRadius: spacing.md,
+      padding: spacing.md,
+      marginBottom: spacing.lg,
+      shadowColor: Colors[colorScheme].tint,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: spacing.sm,
+      elevation: 2,
+    },
+    avatarContainer: {
+      width: sizes.lg,
+      height: sizes.lg,
+      borderRadius: sizes.lg / 2,
+      backgroundColor: Colors[colorScheme].tint,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: spacing.md,
+    },
+    avatarText: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: Colors[colorScheme].foreground,
+    },
+    profileInfo: {
+      flex: 1,
+    },
+    profileName: {
+      fontSize: 20,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      marginBottom: spacing.xs,
+    },
+    profileEmail: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+    },
+    section: {
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 24,
+      shadowColor: Colors[colorScheme].tint,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: spacing.sm,
+      elevation: 2,
+    },
+    sectionTitle: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      marginBottom: spacing.md,
+    },
+    settingItem: {
+      flexDirection: "row",
+      alignItems: "center",
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].icon,
+    },
+    settingIconContainer: {
+      width: sizes.md,
+      height: sizes.md,
+      borderRadius: sizes.md / 2,
+      backgroundColor: `${Colors[colorScheme].tint}20`,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: spacing.md,
+    },
+    settingContent: {
+      flex: 1,
+    },
+    settingTitle: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+      marginBottom: 2,
+    },
+    settingDescription: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+    },
+    settingAction: {
+      fontSize: 14,
+      fontWeight: "500",
+      color: Colors[colorScheme].tint,
+    },
+    logoutButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 12,
+      padding: spacing.md,
+      marginBottom: spacing.lg,
+    },
+    logoutText: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: Colors[colorScheme].tint,
+      marginLeft: spacing.sm,
+    },
+    versionText: {
+      textAlign: "center",
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+      marginBottom: spacing.lg,
+    },
+  });
+}

--- a/app/medication/[id].tsx
+++ b/app/medication/[id].tsx
@@ -4,13 +4,16 @@ import { useMedicationStore } from "@/store/medication-store";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { AlertCircle, Calendar, Clock, Edit, FileText, Trash2 } from "lucide-react-native";
 import { Alert, SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import Button from "../../components/ui/Button";
 import { spacing, sizes } from "../../constants/Theme";
 
 export default function MedicationDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
-  
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
+
   const { medications, deleteMedication } = useMedicationStore();
   const medication = medications.find((med) => med.id === id);
   
@@ -87,12 +90,12 @@ export default function MedicationDetailScreen() {
       {/* Action buttons */}
       <View style={styles.actionButtons}>
         <TouchableOpacity style={styles.actionButton} onPress={handleEdit}>
-          <Edit size={20} color={Colors.light.tint} />
+          <Edit size={20} color={Colors[colorScheme].tint} />
           <Text style={styles.actionButtonText}>Edit</Text>
         </TouchableOpacity>
         
         <TouchableOpacity style={styles.actionButton} onPress={handleDelete}>
-          <Trash2 size={20} color={Colors.light.tint} />
+          <Trash2 size={20} color={Colors[colorScheme].tint} />
           <Text style={[styles.actionButtonText, styles.deleteButtonText]}>Delete</Text>
         </TouchableOpacity>
       </View>
@@ -100,7 +103,7 @@ export default function MedicationDetailScreen() {
       {/* Medication details */}
       <View style={styles.detailsContainer}>
         <View style={styles.detailItem}>
-          <Clock size={20} color={Colors.light.tint} />
+          <Clock size={20} color={Colors[colorScheme].tint} />
           <View style={styles.detailContent}>
             <Text style={styles.detailLabel}>Frequency</Text>
             <Text style={styles.detailValue}>{medication.frequency}</Text>
@@ -109,7 +112,7 @@ export default function MedicationDetailScreen() {
         
         {medication.refillDate && (
           <View style={styles.detailItem}>
-            <Calendar size={20} color={Colors.light.tint} />
+            <Calendar size={20} color={Colors[colorScheme].tint} />
             <View style={styles.detailContent}>
               <Text style={styles.detailLabel}>Next Refill</Text>
               <Text style={styles.detailValue}>
@@ -122,7 +125,7 @@ export default function MedicationDetailScreen() {
         
         {medication.instructions && (
           <View style={styles.detailItem}>
-            <FileText size={20} color={Colors.light.tint} />
+            <FileText size={20} color={Colors[colorScheme].tint} />
             <View style={styles.detailContent}>
               <Text style={styles.detailLabel}>Instructions</Text>
               <Text style={styles.detailValue}>{medication.instructions}</Text>
@@ -136,7 +139,7 @@ export default function MedicationDetailScreen() {
         <View style={styles.warningsContainer}>
           {isLowStock && (
             <View style={styles.warningItem}>
-              <AlertCircle size={20} color={Colors.light.tint} />
+              <AlertCircle size={20} color={Colors[colorScheme].tint} />
               <Text style={styles.warningText}>
                 Low stock: {medication.remainingDoses} doses left
               </Text>
@@ -145,7 +148,7 @@ export default function MedicationDetailScreen() {
           
           {refillSoon && (
             <View style={styles.warningItem}>
-              <AlertCircle size={20} color={Colors.light.tint} />
+              <AlertCircle size={20} color={Colors[colorScheme].tint} />
               <Text style={styles.warningText}>
                 Refill needed in {remainingDays} days
               </Text>
@@ -195,183 +198,185 @@ export default function MedicationDetailScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.light.background,
-  },
-  content: {
-    padding: spacing.md,
-  },
-  notFoundContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: spacing.md,
-  },
-  notFoundText: {
-    fontSize: 18,
-    color: Colors.light.text,
-    marginBottom: spacing.md,
-  },
-  goBackButton: {
-    minWidth: 200,
-  },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: Colors.light.surface,
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 16,
-    shadowColor: Colors.light.tint,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: spacing.sm,
-    elevation: 2,
-  },
-  iconContainer: {
-    width: sizes.lg,
-    height: sizes.lg,
-    borderRadius: sizes.lg / 2,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: spacing.md,
-  },
-  iconText: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: "#FFFFFF",
-  },
-  headerContent: {
-    flex: 1,
-  },
-  medicationName: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: Colors.light.text,
-    marginBottom: 4,
-  },
-  medicationDosage: {
-    fontSize: 18,
-    color: Colors.light.tint,
-    fontWeight: "600",
-  },
-  actionButtons: {
-    flexDirection: "row",
-    marginBottom: 24,
-  },
-  actionButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    marginRight: 16,
-  },
-  actionButtonText: {
-    fontSize: 16,
-    fontWeight: "500",
-    color: Colors.light.tint,
-    marginLeft: 8,
-  },
-  deleteButtonText: {
-    color: Colors.light.tint,
-  },
-  detailsContainer: {
-    backgroundColor: Colors.light.surface,
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 24,
-    shadowColor: Colors.light.tint,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  detailItem: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    marginBottom: 16,
-  },
-  detailContent: {
-    flex: 1,
-    marginLeft: 16,
-  },
-  detailLabel: {
-    fontSize: 14,
-    color: Colors.light.tint,
-    marginBottom: 4,
-  },
-  detailValue: {
-    fontSize: 16,
-    color: Colors.light.text,
-    fontWeight: "500",
-  },
-  warningsContainer: {
-    backgroundColor: "#FFF9E6",
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 24,
-  },
-  warningItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  warningText: {
-    fontSize: 16,
-    color: Colors.light.icon,
-    fontWeight: "500",
-    marginLeft: 12,
-  },
-  supplyContainer: {
-    backgroundColor: Colors.light.surface,
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 24,
-    shadowColor: Colors.light.tint,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  supplyTitle: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: Colors.light.text,
-    marginBottom: 16,
-  },
-  supplyContent: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  supplyDetails: {
-    flex: 1,
-    flexDirection: "row",
-    marginLeft: 16,
-    height: 80,
-    alignItems: "center",
-    justifyContent: "space-around",
-  },
-  supplyItem: {
-    alignItems: "center",
-  },
-  supplyValue: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: Colors.light.text,
-  },
-  supplyLabel: {
-    fontSize: 14,
-    color: Colors.light.text,
-    marginTop: 4,
-  },
-  supplyDivider: {
-    width: 1,
-    height: "50%",
-    backgroundColor: Colors.light.icon,
-  },
-  refillButton: {
-    marginBottom: 24,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    content: {
+      padding: spacing.md,
+    },
+    notFoundContainer: {
+      flex: 1,
+      justifyContent: "center",
+      alignItems: "center",
+      padding: spacing.md,
+    },
+    notFoundText: {
+      fontSize: 18,
+      color: Colors[colorScheme].text,
+      marginBottom: spacing.md,
+    },
+    goBackButton: {
+      minWidth: 200,
+    },
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 16,
+      shadowColor: Colors[colorScheme].tint,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: spacing.sm,
+      elevation: 2,
+    },
+    iconContainer: {
+      width: sizes.lg,
+      height: sizes.lg,
+      borderRadius: sizes.lg / 2,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: spacing.md,
+    },
+    iconText: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: Colors[colorScheme].foreground,
+    },
+    headerContent: {
+      flex: 1,
+    },
+    medicationName: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      marginBottom: 4,
+    },
+    medicationDosage: {
+      fontSize: 18,
+      color: Colors[colorScheme].tint,
+      fontWeight: "600",
+    },
+    actionButtons: {
+      flexDirection: "row",
+      marginBottom: 24,
+    },
+    actionButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      paddingVertical: 8,
+      paddingHorizontal: 16,
+      marginRight: 16,
+    },
+    actionButtonText: {
+      fontSize: 16,
+      fontWeight: "500",
+      color: Colors[colorScheme].tint,
+      marginLeft: 8,
+    },
+    deleteButtonText: {
+      color: Colors[colorScheme].tint,
+    },
+    detailsContainer: {
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 24,
+      shadowColor: Colors[colorScheme].tint,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 2,
+    },
+    detailItem: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      marginBottom: 16,
+    },
+    detailContent: {
+      flex: 1,
+      marginLeft: 16,
+    },
+    detailLabel: {
+      fontSize: 14,
+      color: Colors[colorScheme].tint,
+      marginBottom: 4,
+    },
+    detailValue: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+      fontWeight: "500",
+    },
+    warningsContainer: {
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 24,
+    },
+    warningItem: {
+      flexDirection: "row",
+      alignItems: "center",
+      marginBottom: 8,
+    },
+    warningText: {
+      fontSize: 16,
+      color: Colors[colorScheme].icon,
+      fontWeight: "500",
+      marginLeft: 12,
+    },
+    supplyContainer: {
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 24,
+      shadowColor: Colors[colorScheme].tint,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 2,
+    },
+    supplyTitle: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      marginBottom: 16,
+    },
+    supplyContent: {
+      flexDirection: "row",
+      alignItems: "center",
+    },
+    supplyDetails: {
+      flex: 1,
+      flexDirection: "row",
+      marginLeft: 16,
+      height: 80,
+      alignItems: "center",
+      justifyContent: "space-around",
+    },
+    supplyItem: {
+      alignItems: "center",
+    },
+    supplyValue: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+    },
+    supplyLabel: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+      marginTop: 4,
+    },
+    supplyDivider: {
+      width: 1,
+      height: "50%",
+      backgroundColor: Colors[colorScheme].icon,
+    },
+    refillButton: {
+      marginBottom: 24,
+    },
+  });
+}

--- a/app/medication/add.tsx
+++ b/app/medication/add.tsx
@@ -10,12 +10,15 @@ import {
   TouchableOpacity,
   View
 } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import Button from "../../components/ui/Button";
 import { Colors } from "../../constants/Colors";
 
 export default function AddMedicationScreen() {
   const router = useRouter();
   const { addMedication } = useMedicationStore();
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   
   const [name, setName] = useState("");
   const [dosage, setDosage] = useState("");
@@ -40,7 +43,7 @@ export default function AddMedicationScreen() {
       frequency,
       time,
       instructions,
-      color: Colors.light.primary,
+      color: Colors[colorScheme].primary,
       icon: selectedType.icon,
       quantity: quantity ? parseInt(quantity, 10) : undefined,
       remainingDoses: quantity ? parseInt(quantity, 10) : undefined,
@@ -75,15 +78,15 @@ export default function AddMedicationScreen() {
             <View
               style={[
                 styles.typeIconContainer,
-                { backgroundColor: Colors.light.icon },
+                { backgroundColor: Colors[colorScheme].icon },
               ]}
             >
-              <Pill size={20} color="#FFFFFF" />
+              <Pill size={20} color={Colors[colorScheme].foreground} />
             </View>
             <Text style={styles.selectedTypeText}>{selectedType.name}</Text>
           </View>
           
-          <ChevronDown size={20} color={Colors.light.tint} />
+          <ChevronDown size={20} color={Colors[colorScheme].tint} />
         </TouchableOpacity>
         
         {showTypeSelector && (
@@ -100,10 +103,10 @@ export default function AddMedicationScreen() {
                 <View
                   style={[
                     styles.typeIconContainer,
-                    { backgroundColor: Colors.light.icon },
+                    { backgroundColor: Colors[colorScheme].icon },
                   ]}
                 >
-                  <Pill size={20} color="#FFFFFF" />
+                  <Pill size={20} color={Colors[colorScheme].foreground} />
                 </View>
                 <Text style={styles.typeOptionText}>{type.name}</Text>
               </TouchableOpacity>
@@ -114,9 +117,9 @@ export default function AddMedicationScreen() {
       
       {/* Scan button */}
       <TouchableOpacity style={styles.scanButton} onPress={handleScanPress}>
-        <Camera size={20} color={Colors.light.tint} />
+        <Camera size={20} color={Colors[colorScheme].tint} />
         <Text style={styles.scanButtonText}>Scan Prescription Label</Text>
-        <ChevronRight size={20} color={Colors.light.tint} />
+        <ChevronRight size={20} color={Colors[colorScheme].tint} />
       </TouchableOpacity>
       
       {/* Add Manually button */}
@@ -133,146 +136,148 @@ export default function AddMedicationScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.light.background,
-  },
-  content: {
-    padding: 16,
-    paddingBottom: 40,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: Colors.light.text,
-    marginBottom: 24,
-  },
-  formGroup: {
-    marginBottom: 20,
-  },
-  label: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: Colors.light.text,
-    marginBottom: 8,
-  },
-  input: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    padding: 16,
-    fontSize: 16,
-    color: Colors.light.text,
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  inputText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  inputPlaceholder: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  textArea: {
-    height: 120,
-    textAlignVertical: "top",
-  },
-  helperText: {
-    fontSize: 14,
-    color: Colors.light.text,
-    marginTop: 4,
-  },
-  typeSelector: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    padding: 16,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-  },
-  selectedType: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  typeIconContainer: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 12,
-  },
-  selectedTypeText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  typeOptions: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    marginTop: 8,
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-    overflow: "hidden",
-  },
-  typeOption: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.light.tint,
-  },
-  typeOptionText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  frequencyOptions: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    marginTop: 8,
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-    overflow: "hidden",
-  },
-  frequencyOption: {
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.light.tint,
-  },
-  frequencyOptionText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  scanButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    backgroundColor: `${Colors.light.tint}10`,
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 24,
-  },
-  scanButtonText: {
-    flex: 1,
-    fontSize: 16,
-    fontWeight: "500",
-    color: Colors.light.tint,
-    marginLeft: 12,
-  },
-  saveButton: {
-    marginTop: 16,
-  },
-  addManuallyButton: {
-    marginTop: 16,
-  },
-  addManuallyButtonText: {
-    fontSize: 16,
-    fontWeight: "500",
-    color: Colors.light.tint,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    content: {
+      padding: 16,
+      paddingBottom: 40,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      marginBottom: 24,
+    },
+    formGroup: {
+      marginBottom: 20,
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+      marginBottom: 8,
+    },
+    input: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      padding: 16,
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    },
+    inputText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    inputPlaceholder: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    textArea: {
+      height: 120,
+      textAlignVertical: "top",
+    },
+    helperText: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+      marginTop: 4,
+    },
+    typeSelector: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      padding: 16,
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+    },
+    selectedType: {
+      flexDirection: "row",
+      alignItems: "center",
+    },
+    typeIconContainer: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: 12,
+    },
+    selectedTypeText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    typeOptions: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      marginTop: 8,
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+      overflow: "hidden",
+    },
+    typeOption: {
+      flexDirection: "row",
+      alignItems: "center",
+      padding: 16,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].tint,
+    },
+    typeOptionText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    frequencyOptions: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      marginTop: 8,
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+      overflow: "hidden",
+    },
+    frequencyOption: {
+      padding: 16,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].tint,
+    },
+    frequencyOptionText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    scanButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      backgroundColor: `${Colors[colorScheme].tint}10`,
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 24,
+    },
+    scanButtonText: {
+      flex: 1,
+      fontSize: 16,
+      fontWeight: "500",
+      color: Colors[colorScheme].tint,
+      marginLeft: 12,
+    },
+    saveButton: {
+      marginTop: 16,
+    },
+    addManuallyButton: {
+      marginTop: 16,
+    },
+    addManuallyButtonText: {
+      fontSize: 16,
+      fontWeight: "500",
+      color: Colors[colorScheme].tint,
+    },
+  });
+}

--- a/app/medication/manually.tsx
+++ b/app/medication/manually.tsx
@@ -8,12 +8,15 @@ import {
   TextInput,
   View
 } from "react-native";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import Button from "../../components/ui/Button";
 import { Colors } from "../../constants/Colors";
 
 const Manually = () => {
           const router = useRouter();
   const { addMedication } = useMedicationStore();
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   
   const [name, setName] = useState("");
   const [dosage, setDosage] = useState("");
@@ -39,7 +42,7 @@ const Manually = () => {
       frequency,
       time,
       instructions,
-      color: Colors.light.primary,
+      color: Colors[colorScheme].primary,
       icon: selectedType.icon,
       quantity: quantity ? parseInt(quantity, 10) : undefined,
       remainingDoses: quantity ? parseInt(quantity, 10) : undefined,
@@ -145,138 +148,140 @@ const Manually = () => {
 export default Manually
 
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.light.background,
-  },
-  content: {
-    padding: 16,
-    paddingBottom: 40,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: Colors.light.text,
-    marginBottom: 24,
-  },
-  formGroup: {
-    marginBottom: 20,
-  },
-  label: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: Colors.light.text,
-    marginBottom: 8,
-  },
-  input: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    padding: 16,
-    fontSize: 16,
-    color: Colors.light.text,
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  inputText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  inputPlaceholder: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  textArea: {
-    height: 120,
-    textAlignVertical: "top",
-  },
-  helperText: {
-    fontSize: 14,
-    color: Colors.light.text,
-    marginTop: 4,
-  },
-  typeSelector: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    padding: 16,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-  },
-  selectedType: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  typeIconContainer: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 12,
-  },
-  selectedTypeText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  typeOptions: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    marginTop: 8,
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-    overflow: "hidden",
-  },
-  typeOption: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.light.tint,
-  },
-  typeOptionText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  frequencyOptions: {
-    backgroundColor: Colors.light.tint,
-    borderRadius: 12,
-    marginTop: 8,
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-    overflow: "hidden",
-  },
-  frequencyOption: {
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.light.tint,
-  },
-  frequencyOptionText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  scanButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    backgroundColor: `${Colors.light.tint}10`,
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 24,
-  },
-  scanButtonText: {
-    flex: 1,
-    fontSize: 16,
-    fontWeight: "500",
-    color: Colors.light.tint,
-    marginLeft: 12,
-  },
-  saveButton: {
-    marginTop: 16,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+    },
+    content: {
+      padding: 16,
+      paddingBottom: 40,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: "700",
+      color: Colors[colorScheme].text,
+      marginBottom: 24,
+    },
+    formGroup: {
+      marginBottom: 20,
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+      marginBottom: 8,
+    },
+    input: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      padding: 16,
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    },
+    inputText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    inputPlaceholder: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    textArea: {
+      height: 120,
+      textAlignVertical: "top",
+    },
+    helperText: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+      marginTop: 4,
+    },
+    typeSelector: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      padding: 16,
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+    },
+    selectedType: {
+      flexDirection: "row",
+      alignItems: "center",
+    },
+    typeIconContainer: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: 12,
+    },
+    selectedTypeText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    typeOptions: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      marginTop: 8,
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+      overflow: "hidden",
+    },
+    typeOption: {
+      flexDirection: "row",
+      alignItems: "center",
+      padding: 16,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].tint,
+    },
+    typeOptionText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    frequencyOptions: {
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 12,
+      marginTop: 8,
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+      overflow: "hidden",
+    },
+    frequencyOption: {
+      padding: 16,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors[colorScheme].tint,
+    },
+    frequencyOptionText: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    scanButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      backgroundColor: `${Colors[colorScheme].tint}10`,
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 24,
+    },
+    scanButtonText: {
+      flex: 1,
+      fontSize: 16,
+      fontWeight: "500",
+      color: Colors[colorScheme].tint,
+      marginLeft: 12,
+    },
+    saveButton: {
+      marginTop: 16,
+    },
+  });
+}

--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -29,6 +29,7 @@ import Button from "../../components/ui/Button";
 import { handleParsedText } from "../../services/medicationService";
 import { useMedicationStore } from "../../store/medication-store";
 import { sizes } from "../../constants/Theme";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 // Get screen dimensions for responsive styling
 const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
@@ -48,6 +49,8 @@ interface ExtractedMedication {
 }
 
 export default function ScanMedicationScreen() {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
   const router = useRouter();
   const { setParsedMedication } = useMedicationStore();
   const [permission, requestPermission] = useCameraPermissions();
@@ -794,7 +797,7 @@ export default function ScanMedicationScreen() {
             disabled={isTakingPicture || isProcessing}
           >
             {isTakingPicture || isProcessing ? (
-              <ActivityIndicator color="#FFFFFF" size="large" />
+              <ActivityIndicator color={Colors[colorScheme].foreground} size="large" />
             ) : isRotatingCapture ? (
               <Square size={30} color="#FFFFFF" fill="#FFFFFF" />
             ) : captureMode === "rotating" ? (
@@ -845,7 +848,7 @@ export default function ScanMedicationScreen() {
       {isProcessing && (
         <View style={styles.processingOverlay}>
           <View style={styles.processingCard}>
-            <ActivityIndicator color={Colors.light.tint} size="large" />
+            <ActivityIndicator color={Colors[colorScheme].tint} size="large" />
             <Text style={styles.processingText}>
               {captureMode === "rotating"
                 ? "Processing motion-captured data..."
@@ -869,7 +872,8 @@ export default function ScanMedicationScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#000000",
@@ -1190,18 +1194,18 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     padding: 24,
-    backgroundColor: Colors.light.background,
+    backgroundColor: Colors[colorScheme].background,
   },
   permissionTitle: {
     fontSize: 24,
     fontWeight: "700",
-    color: Colors.light.text,
+    color: Colors[colorScheme].text,
     marginBottom: 16,
     textAlign: "center",
   },
   permissionText: {
     fontSize: 16,
-    color: Colors.light.text,
+    color: Colors[colorScheme].text,
     textAlign: "center",
     marginBottom: 24,
   },
@@ -1260,3 +1264,5 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
 });
+
+}

--- a/components/DoseCard.tsx
+++ b/components/DoseCard.tsx
@@ -78,87 +78,89 @@ export default function DoseCard({ dose, onTake, onSkip }: DoseCardProps) {
 }
 
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
-    backgroundColor: Colors.light.surface,
-    borderRadius: 16,
-    marginBottom: 12,
-    shadowColor:    "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 2,
-    overflow: "hidden",
-  },
-  colorIndicator: {
-    width: 6,
-    height: "100%",
-  },
-  contentContainer: {
-    flex: 1,
-    padding: 16,
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  time: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: Colors.light.text,
-  },
-  status: {
-    fontSize: 14,
-    color: Colors.light.text,
-  },
-  name: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: Colors.light.text,
-    marginBottom: 4,
-  },
-  dosage: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  actionsContainer: {
-    flexDirection: "column",
-    justifyContent: "center",
-    gap: 8,
-    padding: 12,
-  },
-  actionButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  takeButton: {
-    backgroundColor: Colors.light.tint,
-  },
-  skipButton: {
-    backgroundColor: Colors.light.tint,
-  },
-  statusIndicator: {
-    justifyContent: "center",
-    alignItems: "center",
-    paddingRight: 16,
-  },
-  statusDot: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  takenDot: {
-    backgroundColor: Colors.light.tint,
-  },
-  skippedDot: {
-    backgroundColor: Colors.light.tint,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 16,
+      marginBottom: 12,
+      shadowColor: "#000",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 2,
+      overflow: "hidden",
+    },
+    colorIndicator: {
+      width: 6,
+      height: "100%",
+    },
+    contentContainer: {
+      flex: 1,
+      padding: 16,
+    },
+    header: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginBottom: 8,
+    },
+    time: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+    },
+    status: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+    },
+    name: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+      marginBottom: 4,
+    },
+    dosage: {
+      fontSize: 16,
+      color: Colors[colorScheme].text,
+    },
+    actionsContainer: {
+      flexDirection: "column",
+      justifyContent: "center",
+      gap: 8,
+      padding: 12,
+    },
+    actionButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    takeButton: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    skipButton: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    statusIndicator: {
+      justifyContent: "center",
+      alignItems: "center",
+      paddingRight: 16,
+    },
+    statusDot: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    takenDot: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    skippedDot: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+  });
+}

--- a/components/MedicationCard.tsx
+++ b/components/MedicationCard.tsx
@@ -62,67 +62,69 @@ export default function MedicationCard({ medication, onPress }: MedicationCardPr
 }
 
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
-    backgroundColor: Colors.light.surface,
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 12,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  iconContainer: {
-    width: 48,
-    height: 48,
-    borderRadius: 12,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 16,
-  },
-  contentContainer: {
-    flex: 1,
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  name: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: Colors.light.text,
-  },
-  dosage: {
-    fontSize: 16,
-    fontWeight: "500",
-    color: Colors.light.text,
-  },
-  details: {
-    gap: 8,
-  },
-  detailItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  detailText: {
-    fontSize: 14,
-    color: Colors.light.text,
-  },
-  warningContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    marginTop: 4,
-  },
-  warningText: {
-    fontSize: 14,
-    color: Colors.light.text,
-    fontWeight: "500",
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      backgroundColor: Colors[colorScheme].surface,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 12,
+      shadowColor: "#000",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 2,
+    },
+    iconContainer: {
+      width: 48,
+      height: 48,
+      borderRadius: 12,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: 16,
+    },
+    contentContainer: {
+      flex: 1,
+    },
+    header: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginBottom: 8,
+    },
+    name: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: Colors[colorScheme].text,
+    },
+    dosage: {
+      fontSize: 16,
+      fontWeight: "500",
+      color: Colors[colorScheme].text,
+    },
+    details: {
+      gap: 8,
+    },
+    detailItem: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+    },
+    detailText: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+    },
+    warningContainer: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+      marginTop: 4,
+    },
+    warningText: {
+      fontSize: 14,
+      color: Colors[colorScheme].text,
+      fontWeight: "500",
+    },
+  });
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -108,69 +108,71 @@ export default function Button({
 }
 
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 12,
-    gap: 8,
-  },
-  primaryContainer: {
-    backgroundColor: Colors.light.tint,
-  },
-  secondaryContainer: {
-    backgroundColor: Colors.light.surface,
-  },
-  outlineContainer: {
-    backgroundColor: "transparent",
-    borderWidth: 1,
-    borderColor: Colors.light.tint,
-  },
-  ghostContainer: {
-    backgroundColor: "transparent",
-  },
-  smallContainer: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-  },
-  mediumContainer: {
-    paddingVertical: 12,
-    paddingHorizontal: 24,
-  },
-  largeContainer: {
-    paddingVertical: 16,
-    paddingHorizontal: 32,
-  },
-  disabledContainer: {
-    opacity: 0.5,
-  },
-  text: {
-    fontWeight: "600",
-    textAlign: "center",
-  },
-  primaryText: {
-    color: "#FFFFFF",
-  },
-  secondaryText: {
-    color: Colors.light.text,
-  },
-  outlineText: {
-    color: Colors.light.tint,
-  },
-  ghostText: {
-    color: Colors.light.tint,
-  },
-  smallText: {
-    fontSize: 14,
-  },
-  mediumText: {
-    fontSize: 16,
-  },
-  largeText: {
-    fontSize: 18,
-  },
-  disabledText: {
-    opacity: 0.7,
-  },
-});
+function createStyles(colorScheme: 'light' | 'dark') {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: 12,
+      gap: 8,
+    },
+    primaryContainer: {
+      backgroundColor: Colors[colorScheme].tint,
+    },
+    secondaryContainer: {
+      backgroundColor: Colors[colorScheme].surface,
+    },
+    outlineContainer: {
+      backgroundColor: "transparent",
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].tint,
+    },
+    ghostContainer: {
+      backgroundColor: "transparent",
+    },
+    smallContainer: {
+      paddingVertical: 8,
+      paddingHorizontal: 16,
+    },
+    mediumContainer: {
+      paddingVertical: 12,
+      paddingHorizontal: 24,
+    },
+    largeContainer: {
+      paddingVertical: 16,
+      paddingHorizontal: 32,
+    },
+    disabledContainer: {
+      opacity: 0.5,
+    },
+    text: {
+      fontWeight: "600",
+      textAlign: "center",
+    },
+    primaryText: {
+      color: Colors[colorScheme].foreground,
+    },
+    secondaryText: {
+      color: Colors[colorScheme].text,
+    },
+    outlineText: {
+      color: Colors[colorScheme].tint,
+    },
+    ghostText: {
+      color: Colors[colorScheme].tint,
+    },
+    smallText: {
+      fontSize: 14,
+    },
+    mediumText: {
+      fontSize: 16,
+    },
+    largeText: {
+      fontSize: 18,
+    },
+    disabledText: {
+      opacity: 0.7,
+    },
+  });
+}

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -17,6 +17,7 @@ export const Colors = {
     secondary: '#64748b',
     tint: primaryColorLight,
     icon: '#687076',
+    foreground: '#ffffff',
     tabIconDefault: '#687076',
 
     tabIconSelected: primaryColorLight,
@@ -31,6 +32,7 @@ export const Colors = {
     secondary: '#94a3b8',
     tint: primaryColorDark,
     icon: '#9BA1A6',
+    foreground: '#ffffff',
     tabIconDefault: '#9BA1A6',
 
     tabIconSelected: primaryColorDark,


### PR DESCRIPTION
## Summary
- use dynamic `useColorScheme` across tabs, components, and medication screens
- centralize foreground color token
- remove hard-coded light palette values

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891a04eaa188324a28b3613cd3ac18e