### PR TITLE
fix: remove whitespace nodes from medication stack

### DIFF
--- a/app/medication/_layout.tsx
+++ b/app/medication/_layout.tsx
@@ -11,14 +11,9 @@ const screens = [
 
 
 export default function MedicationLayout() {
-
   return (
-    <Stack>
-
-      {screens.map((cfg) => (
+    <Stack>{screens.map((cfg) => (
         <Stack.Screen key={cfg.name} {...cfg} />
-      ))}
-
-    </Stack>
+      ))}</Stack>
   );
 }


### PR DESCRIPTION
## Summary
- ensure medication stack renders only Stack.Screen components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898030df0088324bdc04940acaf5551