### PR TITLE
Pause frame analysis during recording

### DIFF
--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -89,6 +89,7 @@ export default function ScanMedicationScreen() {
   }, []);
 
   const startFrameAnalysis = () => {
+    if (isRecording) return;
     frameAnalysisInterval.current = setInterval(async () => {
       if (
         cameraRef.current &&
@@ -209,11 +210,16 @@ export default function ScanMedicationScreen() {
 
   const startRecording = async () => {
     if (isRecording || isProcessing || !cameraRef.current) return;
-   
+
     setIsRecording(true);
     setRotationProgress(0);
     progressAnimation.setValue(0);
     rotationTracker.startTracking();
+
+    if (frameAnalysisInterval.current) {
+      clearInterval(frameAnalysisInterval.current);
+      frameAnalysisInterval.current = null;
+    }
     
     const duration = 6000;
     const milestones = [0.25, 0.5, 0.75, 1];
@@ -262,6 +268,7 @@ export default function ScanMedicationScreen() {
       progressAnimation.removeListener(listener);
       setIsRecording(false);
       rotationTracker.reset();
+      startFrameAnalysis();
     }
   };
 


### PR DESCRIPTION
## Summary
- Skip frame analysis while recording to prevent conflicts with video capture.
- Stop frame analysis when recording starts and restart once video processing completes.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898030fdc388324be381f92754acdce