### PR TITLE
Guard video recording initialization

### DIFF
--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -61,6 +61,7 @@ export default function ScanMedicationScreen() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [recordingStarted, setRecordingStarted] = useState(false);
+  const [canStopRecording, setCanStopRecording] = useState(false);
   const [facing, setFacing] = useState<CameraType>("back");
   const [flashEnabled, setFlashEnabled] = useState(false);
   const [rotationProgress, setRotationProgress] = useState(0);
@@ -78,7 +79,8 @@ export default function ScanMedicationScreen() {
   const rotationTracker = useRef(new RotationTracker()).current;
   const frameAnalysisInterval = useRef<number | null>(null);
   const alternativeScanner = useRef(new AlternativeScanningManager()).current;
- const isAnalyzingFrame = useRef(false);
+  const isAnalyzingFrame = useRef(false);
+  const recordingPromise = useRef<Promise<any> | null>(null);
   useEffect(() => {
     // Start frame analysis when camera is ready
     if (permission?.granted && !isProcessing) {
@@ -240,7 +242,9 @@ export default function ScanMedicationScreen() {
     setRotationProgress(0);
     progressAnimation.setValue(0);
     rotationTracker.startTracking();
-
+    setRecordingStarted(false);
+    setCanStopRecording(false);
+    recordingPromise.current = null;
 
     if (frameAnalysisInterval.current) {
       clearInterval(frameAnalysisInterval.current);
@@ -287,12 +291,15 @@ export default function ScanMedicationScreen() {
 
     while (attempt < maxAttempts && !video) {
       try {
-        const recordingPromise = cameraRef.current.recordAsync(recordingOptions);
+        recordingPromise.current = cameraRef.current.recordAsync(recordingOptions);
         setRecordingStarted(true);
-        video = await recordingPromise;
+        setTimeout(() => setCanStopRecording(true), 100);
+        video = await recordingPromise.current;
       } catch (error) {
         attempt++;
+        recordingPromise.current = null;
         setRecordingStarted(false);
+        setCanStopRecording(false);
         console.error("Recording error:", error);
         if (attempt < maxAttempts) {
           Alert.alert("Recording failed", "Retrying...");
@@ -313,15 +320,26 @@ export default function ScanMedicationScreen() {
       progressAnimation.removeListener(listener);
       setIsRecording(false);
       setRecordingStarted(false);
+      setCanStopRecording(false);
+      recordingPromise.current = null;
       rotationTracker.reset();
       startFrameAnalysis();
     }
   };
 
   const stopRecording = () => {
-    if (!cameraRef.current || !recordingStarted) return;
-    // @ts-ignore: stopRecording may not be typed on cameraRef
-    cameraRef.current.stopRecording();
+    if (
+      !cameraRef.current ||
+      !recordingStarted ||
+      !canStopRecording ||
+      !recordingPromise.current
+    )
+      return;
+    setCanStopRecording(false);
+    setTimeout(() => {
+      // @ts-ignore: stopRecording may not be typed on cameraRef
+      cameraRef.current?.stopRecording();
+    }, 50);
   };
 
   const toggleCameraFacing = () => {
@@ -428,11 +446,14 @@ export default function ScanMedicationScreen() {
           <TouchableOpacity
             style={[
               styles.captureButton,
-              isProcessing && styles.disabledButton,
+              (isProcessing || (isRecording && !canStopRecording)) &&
+                styles.disabledButton,
               isRecording && styles.stopButton,
             ]}
             onPress={isRecording ? stopRecording : startRecording}
-            disabled={isProcessing}
+            disabled={
+              isProcessing || (isRecording && !canStopRecording)
+            }
           >
             {isRecording ? (
               <Square size={30} color="#FFFFFF" fill="#FFFFFF" />


### PR DESCRIPTION
## Summary
- Track recording lifecycle with `canStopRecording` flag and promise reference
- Disable stop button until recording fully begins
- Guard `stopRecording` with extra checks and short delay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68981353e81c8324b164bb6c578ff883