### PR TITLE
Fix stray text node in scan screen

### DIFF
--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -372,7 +372,7 @@ export default function ScanMedicationScreen() {
         flash={flashEnabled ? "on" : "off"}
         focusable
       ></CameraView>
-       <View> {/* Enhanced Guidance Overlay */}
+      <View>{/* Enhanced Guidance Overlay */}
         {showGuidance && (
           <CylindricalGuidanceOverlay
             isRecording={isRecording}


### PR DESCRIPTION
## Summary
- remove stray whitespace that produced text node in medication scan screen

## Testing
- `npm run lint`
- `npm start >/tmp/expo.log && tail -n 20 /tmp/expo.log`


------
https://chatgpt.com/codex/tasks/task_e_6898135465cc8324acd46764f4bba60e