### PR TITLE
Enable video mode for medication scanner

### DIFF
--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -544,6 +544,7 @@ export default function ScanMedicationScreen() {
       <CameraView
         style={styles.camera}
         facing={facing}
+        mode="video"
         ref={cameraRef}
         flash={flashEnabled ? "on" : "off"}
         focusable


### PR DESCRIPTION
## Summary
- ensure camera view uses video mode in medication scanning so recording resolves

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689835484eb88324948be70b58a7351e