### PR TITLE
feat: add voice label entry

### DIFF
--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -6,6 +6,10 @@ import {
   useCameraPermissions,
   useMicrophonePermissions,
 } from "expo-camera";
+import {
+  ExpoSpeechRecognitionModule,
+  useSpeechRecognitionEvent,
+} from "expo-speech-recognition";
 import * as FileSystem from "expo-file-system";
 import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
@@ -77,6 +81,7 @@ export default function ScanMedicationScreen() {
     estimatedCompleteness: 0,
   });
   const [showFallbackOptions, setShowFallbackOptions] = useState(false);
+  const [isListening, setIsListening] = useState(false);
   
   // Refs
   const cameraRef = useRef<CameraView | null>(null);
@@ -118,6 +123,7 @@ export default function ScanMedicationScreen() {
           console.log('Cleanup recording stop error:', error);
         }
       }
+      ExpoSpeechRecognitionModule.stop();
     };
   }, []);
 
@@ -239,6 +245,64 @@ export default function ScanMedicationScreen() {
       setIsProcessing(false);
     }
   };
+
+  const handleVoiceInput = async () => {
+    try {
+      if (!micPermission?.granted) {
+        const status = await requestMicPermission();
+        if (!status.granted) {
+          Alert.alert("Microphone permission required");
+          return;
+        }
+      }
+      setIsListening(true);
+      setShowFallbackOptions(false);
+      await ExpoSpeechRecognitionModule.start({
+        lang: "en-US",
+        interimResults: false,
+      });
+    } catch (error) {
+      console.error('Voice input error:', error);
+      setIsListening(false);
+      setShowFallbackOptions(true);
+    }
+  };
+
+  useSpeechRecognitionEvent("result", async (event) => {
+    if (event.isFinal && event.results.length > 0) {
+      const transcript = event.results[0].transcript;
+      setIsListening(false);
+      try {
+        setIsProcessing(true);
+        const res = await handleParsedText(transcript);
+        if (
+          res &&
+          res.data &&
+          res.data.parseMedicationLabel &&
+          res.data.parseMedicationLabel.data
+        ) {
+          await navigateToConfirmation(res.data.parseMedicationLabel.data);
+        } else {
+          setShowFallbackOptions(true);
+        }
+      } catch (err) {
+        console.log('Speech processing error:', err);
+        setShowFallbackOptions(true);
+      } finally {
+        setIsProcessing(false);
+        ExpoSpeechRecognitionModule.stop();
+      }
+    }
+  });
+
+  useSpeechRecognitionEvent("error", () => {
+    setIsListening(false);
+    setShowFallbackOptions(true);
+  });
+
+  useSpeechRecognitionEvent("end", () => {
+    setIsListening(false);
+  });
 
   const processVideo = async (uri: string) => {
     console.log("Processing video URI:", uri);
@@ -549,6 +613,7 @@ export default function ScanMedicationScreen() {
         focusable
         animateShutter={false}
         onCameraReady={onCameraReady}
+        mode="video"
       />
       
       {/* Enhanced Guidance Overlay */}
@@ -665,6 +730,15 @@ export default function ScanMedicationScreen() {
         </View>
       )}
 
+      {isListening && (
+        <View style={styles.processingOverlay}>
+          <View style={styles.processingCard}>
+            <ActivityIndicator color={Colors[colorScheme].tint} size="large" />
+            <Text style={styles.processingText}>Listening...</Text>
+          </View>
+        </View>
+      )}
+
       {showFallbackOptions && (
         <View style={styles.processingOverlay}>
           <View style={styles.processingCard}>
@@ -691,6 +765,12 @@ export default function ScanMedicationScreen() {
               title="Manual Guidance"
               variant="secondary"
               onPress={() => handleAlternativeScan('manual_guide')}
+              style={styles.fallbackButton}
+            />
+            <Button
+              title="Speak Label"
+              variant="secondary"
+              onPress={handleVoiceInput}
               style={styles.fallbackButton}
             />
             <Button

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "expo-router": "~5.1.4",
         "expo-sensors": "^14.1.4",
         "expo-speech": "~13.1.0",
+        "expo-speech-recognition": "^2.1.1",
         "expo-splash-screen": "^0.30.10",
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
@@ -7603,6 +7604,17 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-speech-recognition": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-2.1.1.tgz",
+      "integrity": "sha512-TISNa9UIi01TlZfxyXU6jLC4f18yyXJgIMRM30PqSETbbQI8BafgkCIRBnZVvGR3wbyeNvG9zHc76du/vuiPLQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "expo-router": "~5.1.4",
     "expo-sensors": "^14.1.4",
     "expo-speech": "~13.1.0",
+    "expo-speech-recognition": "^2.1.1",
     "expo-splash-screen": "^0.30.10",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",


### PR DESCRIPTION
## Summary
- allow speaking medication label as fallback and process text for confirmation
- add `expo-speech-recognition` dependency
- set CameraView to use video mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898389996708324a3493963732a0222