### PR TITLE
feat: replace mlkit ocr with expo module

### DIFF
--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -37,7 +37,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import MlkitOcr from "react-native-mlkit-ocr";
+import ExpoMlkitOcr from "expo-mlkit-ocr";
 import Svg, { Circle } from "react-native-svg";
 import { CylindricalGuidanceOverlay } from "../../components/CylindricalGuidanceOverlay";
 import Button from "../../components/ui/Button";
@@ -324,12 +324,9 @@ if (status === 'granted') {
       setIsProcessing(true);
       flattenedUri = await unwrapCylindricalLabel(uri);
       console.log("Flattened label URI:", flattenedUri);
-      const recognized = await MlkitOcr.detectFromUri(flattenedUri);
+      const recognized = await ExpoMlkitOcr.recognizeText(flattenedUri);
       console.log("OCR recognized text:", recognized);
-      const labelText = recognized
-        .map((block) => block.text)
-        .join("\n")
-        .trim();
+      const labelText = recognized.text.trim();
       const res = await handleParsedText(labelText);
       if (
         res &&

--- a/docs/CYLINDRICAL_SCANNING_METHODOLOGY.md
+++ b/docs/CYLINDRICAL_SCANNING_METHODOLOGY.md
@@ -37,7 +37,7 @@ The current methodology employs a **video recording + backend unwrapping** strat
 #### Frontend Components:
 - **Camera Interface**: `expo-camera` with CameraView
 - **Recording Control**: 6-second timed recording with progress indicator
-- **OCR Engine**: `react-native-mlkit-ocr` for on-device text recognition
+- **OCR Engine**: `expo-mlkit-ocr` for on-device text recognition
 - **Feedback Systems**: Haptic feedback (`expo-haptics`) and voice announcements (`expo-speech`)
 
 #### Backend Services:

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.7",
         "expo-media-library": "~17.1.7",
+        "expo-mlkit-ocr": "^2.0.1",
         "expo-router": "~5.1.4",
         "expo-sensors": "^14.1.4",
         "expo-speech": "~13.1.0",
@@ -51,7 +52,6 @@
         "react-native": "^0.79.5",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-mime-types": "^2.5.0",
-        "react-native-mlkit-ocr": "^0.3.0",
         "react-native-paper": "^5.14.5",
         "react-native-paper-dates": "^0.22.47",
         "react-native-paper-dropdown": "^2.3.1",
@@ -7503,6 +7503,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-mlkit-ocr": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/expo-mlkit-ocr/-/expo-mlkit-ocr-2.0.1.tgz",
+      "integrity": "sha512-kX3lytftnPL0slAD+hwDhNggkLJhNqAsX9/qrG4gyWjOBt8JsJvzsgta7ix8pYMqneBF4eAsbEQjxbPThrpbQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native": "^0.79.2"
+      },
+      "peerDependencies": {
+        "expo-modules-core": ">=1.0.0",
+        "react-native": ">=0.63"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.1.14",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.14.tgz",
@@ -11985,16 +11998,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/react-native-mlkit-ocr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-mlkit-ocr/-/react-native-mlkit-ocr-0.3.0.tgz",
-      "integrity": "sha512-8oNJwNMGsUup41nWlKA01iW6xiNkCcXM3ANDsOKKijvsrd3eWNs7kL0Yhpt3Cq64zSyjoeqkdTdOCDiI6Pv6KA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-paper": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-native": "^0.79.5",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-mime-types": "^2.5.0",
-    "react-native-mlkit-ocr": "^0.3.0",
+    "expo-mlkit-ocr": "^2.0.1",
     "react-native-paper": "^5.14.5",
     "react-native-paper-dates": "^0.22.47",
     "react-native-paper-dropdown": "^2.3.1",


### PR DESCRIPTION
## Summary
- switch to `expo-mlkit-ocr` for Expo-managed builds
- update scanning utilities and docs for new OCR API
- bundle native module with prebuild

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `CI=1 npx expo prebuild --platform android`


------
https://chatgpt.com/codex/tasks/task_e_68985ad63f888324807c6ec297eaf06e