### PR TITLE
feat: expose alternative medication entry methods

### DIFF
--- a/app/medication/add.tsx
+++ b/app/medication/add.tsx
@@ -2,7 +2,15 @@ import { medicationTypes } from "@/constants/medications";
 // TODO: Re-enable when form functionality is implemented
 // import { useMedicationStore } from "@/store/medication-store";
 import { useRouter } from "expo-router";
-import { Camera, ChevronRight, Pill } from "lucide-react-native";
+import {
+  Camera,
+  ChevronRight,
+  Pill,
+  Layers,
+  Image as ImageIcon,
+  Hand,
+  Mic,
+} from "lucide-react-native";
 import { useState } from "react";
 import {
   ScrollView,
@@ -62,7 +70,23 @@ export default function AddMedicationScreen() {
   const handleScanPress = () => {
     router.push("/medication/scan");
   };
-  
+
+  const handlePhotoStitchingPress = () => {
+    router.push({ pathname: "/medication/scan", params: { method: "photo_stitching" } });
+  };
+
+  const handleSinglePhotoPress = () => {
+    router.push({ pathname: "/medication/scan", params: { method: "single_photo" } });
+  };
+
+  const handleManualGuidePress = () => {
+    router.push({ pathname: "/medication/scan", params: { method: "manual_guide" } });
+  };
+
+  const handleSpeakLabelPress = () => {
+    router.push({ pathname: "/medication/scan", params: { method: "voice" } });
+  };
+
   const handleAddManuallyPress = () => {
     router.push("/medication/manually");
   };
@@ -111,7 +135,47 @@ export default function AddMedicationScreen() {
         <ChevronRight size={20} color={Colors[colorScheme].tint} />
 
       </TouchableOpacity>
-      
+
+      {/* Photo Stitching button */}
+      <TouchableOpacity
+        style={styles.scanButton}
+        onPress={handlePhotoStitchingPress}
+      >
+        <Layers size={20} color={Colors[colorScheme].tint} />
+        <Text style={styles.scanButtonText}>Photo Stitching</Text>
+        <ChevronRight size={20} color={Colors[colorScheme].tint} />
+      </TouchableOpacity>
+
+      {/* Single Photo button */}
+      <TouchableOpacity
+        style={styles.scanButton}
+        onPress={handleSinglePhotoPress}
+      >
+        <ImageIcon size={20} color={Colors[colorScheme].tint} />
+        <Text style={styles.scanButtonText}>Single Photo</Text>
+        <ChevronRight size={20} color={Colors[colorScheme].tint} />
+      </TouchableOpacity>
+
+      {/* Manual Guidance button */}
+      <TouchableOpacity
+        style={styles.scanButton}
+        onPress={handleManualGuidePress}
+      >
+        <Hand size={20} color={Colors[colorScheme].tint} />
+        <Text style={styles.scanButtonText}>Manual Guidance</Text>
+        <ChevronRight size={20} color={Colors[colorScheme].tint} />
+      </TouchableOpacity>
+
+      {/* Speak Label button */}
+      <TouchableOpacity
+        style={styles.scanButton}
+        onPress={handleSpeakLabelPress}
+      >
+        <Mic size={20} color={Colors[colorScheme].tint} />
+        <Text style={styles.scanButtonText}>Speak Label</Text>
+        <ChevronRight size={20} color={Colors[colorScheme].tint} />
+      </TouchableOpacity>
+
       {/* Add Manually button */}
       <TouchableOpacity
         style={styles.scanButton}

--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -9,7 +9,7 @@ import {
 import * as FileSystem from "expo-file-system";
 import * as Haptics from "expo-haptics";
 import * as MediaLibrary from 'expo-media-library';
-import { useRouter } from "expo-router";
+import { useRouter, useLocalSearchParams } from "expo-router";
 import * as Speech from "expo-speech";
 import {
   ExpoSpeechRecognitionModule,
@@ -61,6 +61,7 @@ export default function ScanMedicationScreen() {
   const colorScheme = useColorScheme() ?? "light";
   const styles = createStyles(colorScheme);
   const router = useRouter();
+  const { method } = useLocalSearchParams<{ method?: string }>();
   const { setParsedMedication } = useMedicationStore();
   const [permission, requestPermission] = useCameraPermissions();
   const [micPermission, requestMicPermission] = useMicrophonePermissions();
@@ -303,6 +304,20 @@ export default function ScanMedicationScreen() {
   useSpeechRecognitionEvent("end", () => {
     setIsListening(false);
   });
+
+  useEffect(() => {
+    if (!method) return;
+    if (
+      method === "photo_stitching" ||
+      method === "single_photo" ||
+      method === "manual_guide" ||
+      method === "auto"
+    ) {
+      handleAlternativeScan(method as any);
+    } else if (method === "voice") {
+      handleVoiceInput();
+    }
+  }, [method]);
 
   const processVideo = async (uri: string) => {
     const { status } = await MediaLibrary.requestPermissionsAsync();


### PR DESCRIPTION
## Summary
- show photo stitching, single photo, manual guidance, and voice options on add medication screen
- allow scan screen to trigger specific alternative methods via query parameter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689867a2994083248264a4746d05c51f