### PR TITLE
feat: add dedicated voice input screen

### DIFF
--- a/app/medication/_layout.tsx
+++ b/app/medication/_layout.tsx
@@ -5,6 +5,7 @@ const screens = [
   { name: "add", options: { title: "Add Medication" } },
   { name: "scan", options: { title: "Scan Medication" } },
   { name: "manually", options: { title: "Add Manually" } },
+  { name: "voice", options: { title: "Voice Input" } },
   { name: "confirmation", options: { title: "Confirm Medication" } },
   { name: "[id]", options: { title: "Medication" } },
 ];

--- a/app/medication/voice.tsx
+++ b/app/medication/voice.tsx
@@ -1,0 +1,115 @@
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { useMicrophonePermissions } from "expo-camera";
+import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from "expo-speech-recognition";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { Alert, ActivityIndicator, SafeAreaView, StyleSheet, Text, View } from "react-native";
+import Button from "../../components/ui/Button";
+import { handleParsedText } from "../../services/medicationService";
+import { useMedicationStore } from "../../store/medication-store";
+
+export default function MedicationVoiceScreen() {
+  const colorScheme = useColorScheme() ?? "light";
+  const styles = createStyles(colorScheme);
+  const router = useRouter();
+  const { setParsedMedication } = useMedicationStore();
+  const [micPermission, requestMicPermission] = useMicrophonePermissions();
+  const [isListening, setIsListening] = useState(false);
+
+  const startListening = async () => {
+    try {
+      if (!micPermission?.granted) {
+        const status = await requestMicPermission();
+        if (!status.granted) {
+          Alert.alert("Microphone permission required");
+          return;
+        }
+      }
+      setIsListening(true);
+      await ExpoSpeechRecognitionModule.start({
+        lang: "en-US",
+        interimResults: false,
+      });
+    } catch (error) {
+      console.error("Voice start error:", error);
+      setIsListening(false);
+    }
+  };
+
+  const stopListening = () => {
+    ExpoSpeechRecognitionModule.stop();
+    setIsListening(false);
+  };
+
+  useSpeechRecognitionEvent("result", async (event) => {
+    if (event.isFinal && event.results.length > 0) {
+      const transcript = event.results[0].transcript;
+      try {
+        const res = await handleParsedText(transcript);
+        if (res?.data?.parseMedicationLabel?.data) {
+          setParsedMedication(res.data.parseMedicationLabel.data);
+          router.push("/medication/confirmation");
+        }
+      } catch (err) {
+        console.log("Speech processing error:", err);
+      } finally {
+        setIsListening(false);
+        ExpoSpeechRecognitionModule.stop();
+      }
+    }
+  });
+
+  useSpeechRecognitionEvent("error", () => {
+    setIsListening(false);
+  });
+
+  useSpeechRecognitionEvent("end", () => {
+    setIsListening(false);
+  });
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        {isListening ? (
+          <>
+            <View style={styles.indicator}>
+              <ActivityIndicator color={Colors[colorScheme].tint} />
+              <Text style={styles.indicatorText}>Listening...</Text>
+            </View>
+            <Button title="Stop" onPress={stopListening} style={styles.button} />
+          </>
+        ) : (
+          <Button title="Start" onPress={startListening} style={styles.button} />
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(colorScheme: "light" | "dark") {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: "center",
+      alignItems: "center",
+      backgroundColor: Colors[colorScheme].background,
+    },
+    content: {
+      alignItems: "center",
+      gap: 20,
+    },
+    indicator: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+    },
+    indicatorText: {
+      color: Colors[colorScheme].text,
+      fontSize: 16,
+    },
+    button: {
+      width: 200,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated voice input screen for medication entry
- register the voice route and navigate to it from scan fallback
- remove inline voice handling from the scan workflow

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899832c010c8324a61ab4306f498396