### PR TITLE
refactor: remove speech recognition

### DIFF
--- a/app/medication/voice.tsx
+++ b/app/medication/voice.tsx
@@ -1,88 +1,14 @@
 import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme";
-import { useMicrophonePermissions } from "expo-camera";
-import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from "expo-speech-recognition";
-import { useRouter } from "expo-router";
-import { useState } from "react";
-import { Alert, ActivityIndicator, SafeAreaView, StyleSheet, Text, View } from "react-native";
-import Button from "../../components/ui/Button";
-import { handleParsedText } from "../../services/medicationService";
-import { useMedicationStore } from "../../store/medication-store";
+import { SafeAreaView, StyleSheet, Text } from "react-native";
 
 export default function MedicationVoiceScreen() {
   const colorScheme = useColorScheme() ?? "light";
   const styles = createStyles(colorScheme);
-  const router = useRouter();
-  const { setParsedMedication } = useMedicationStore();
-  const [micPermission, requestMicPermission] = useMicrophonePermissions();
-  const [isListening, setIsListening] = useState(false);
-
-  const startListening = async () => {
-    try {
-      if (!micPermission?.granted) {
-        const status = await requestMicPermission();
-        if (!status.granted) {
-          Alert.alert("Microphone permission required");
-          return;
-        }
-      }
-      setIsListening(true);
-      await ExpoSpeechRecognitionModule.start({
-        lang: "en-US",
-        interimResults: false,
-      });
-    } catch (error) {
-      console.error("Voice start error:", error);
-      setIsListening(false);
-    }
-  };
-
-  const stopListening = () => {
-    ExpoSpeechRecognitionModule.stop();
-    setIsListening(false);
-  };
-
-  useSpeechRecognitionEvent("result", async (event) => {
-    if (event.isFinal && event.results.length > 0) {
-      const transcript = event.results[0].transcript;
-      try {
-        const res = await handleParsedText(transcript);
-        if (res?.data?.parseMedicationLabel?.data) {
-          setParsedMedication(res.data.parseMedicationLabel.data);
-          router.push("/medication/confirmation");
-        }
-      } catch (err) {
-        console.log("Speech processing error:", err);
-      } finally {
-        setIsListening(false);
-        ExpoSpeechRecognitionModule.stop();
-      }
-    }
-  });
-
-  useSpeechRecognitionEvent("error", () => {
-    setIsListening(false);
-  });
-
-  useSpeechRecognitionEvent("end", () => {
-    setIsListening(false);
-  });
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.content}>
-        {isListening ? (
-          <>
-            <View style={styles.indicator}>
-              <ActivityIndicator color={Colors[colorScheme].tint} />
-              <Text style={styles.indicatorText}>Listening...</Text>
-            </View>
-            <Button title="Stop" onPress={stopListening} style={styles.button} />
-          </>
-        ) : (
-          <Button title="Start" onPress={startListening} style={styles.button} />
-        )}
-      </View>
+      <Text style={styles.message}>Voice input is currently unavailable.</Text>
     </SafeAreaView>
   );
 }
@@ -95,21 +21,9 @@ function createStyles(colorScheme: "light" | "dark") {
       alignItems: "center",
       backgroundColor: Colors[colorScheme].background,
     },
-    content: {
-      alignItems: "center",
-      gap: 20,
-    },
-    indicator: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 8,
-    },
-    indicatorText: {
+    message: {
       color: Colors[colorScheme].text,
       fontSize: 16,
-    },
-    button: {
-      width: 200,
     },
   });
 }


### PR DESCRIPTION
## Summary
- simplify voice input screen by removing speech recognition hooks
- retain mic permission check for scan video recording

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68998e97ea548324ac7279e4f8a4df40