### PR TITLE
feat: unify single photo scanner UI

### DIFF
--- a/app/medication/scan.tsx
+++ b/app/medication/scan.tsx
@@ -34,6 +34,7 @@ import Svg, { Circle } from "react-native-svg";
 import CameraControls from "../../components/CameraControls";
 import { CylindricalGuidanceOverlay } from "../../components/CylindricalGuidanceOverlay";
 import PanoramaCapture from "../../components/PanoramaCapture";
+import SinglePhotoCapture from "../../components/SinglePhotoCapture";
 import Button from "../../components/ui/Button";
 import { handleParsedText } from "../../services/medicationService";
 import { useMedicationStore } from "../../store/medication-store";
@@ -50,6 +51,7 @@ import {
   cleanupAlternativeScanFiles,
 } from "../../utils/scanners/alternativeManager";
 import { PhotoStitchingScanner } from "../../utils/scanners/photoStitchingScanner";
+import { SinglePhotoScanner } from "../../utils/scanners/singlePhotoScanner";
 const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
 
 export default function ScanMedicationScreen() {
@@ -81,6 +83,7 @@ export default function ScanMedicationScreen() {
   });
   const [showFallbackOptions, setShowFallbackOptions] = useState(false);
   const [showPanoramaCapture, setShowPanoramaCapture] = useState(false);
+  const [showSinglePhotoCapture, setShowSinglePhotoCapture] = useState(false);
   
   // Refs
   const cameraRef = useRef<CameraView | null>(null);
@@ -88,6 +91,7 @@ export default function ScanMedicationScreen() {
   const rotationTracker = useRef(new RotationTracker()).current;
   const frameAnalysisInterval = useRef<number | null>(null);
   const alternativeScanner = useRef(new AlternativeScanningManager()).current;
+  const singlePhotoScanner = useRef(new SinglePhotoScanner()).current;
   const isAnalyzingFrame = useRef(false);
   const recordingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isComponentMounted = useRef(true);
@@ -258,6 +262,11 @@ export default function ScanMedicationScreen() {
   const handleAlternativeScan = async (
     method: 'photo_stitching' | 'single_photo'  | 'auto' = 'auto'
   ) => {
+    if (method === 'single_photo') {
+      setShowFallbackOptions(false);
+      setShowSinglePhotoCapture(true);
+      return;
+    }
     let result;
     try {
       setProcessingMedia('photo');
@@ -335,10 +344,53 @@ export default function ScanMedicationScreen() {
     setShowFallbackOptions(true);
   };
 
+  const handleSinglePhotoResult = async (imageUri: string) => {
+    setShowSinglePhotoCapture(false);
+    let result;
+    try {
+      setProcessingMedia('photo');
+      setIsProcessing(true);
+      result = await singlePhotoScanner.performSinglePhotoScan(imageUri);
+      if (result.success && result.extractedText) {
+        const res = await handleParsedText(result.extractedText);
+        if (
+          res &&
+          res.data &&
+          res.data.parseMedicationLabel &&
+          res.data.parseMedicationLabel.data
+        ) {
+          await navigateToConfirmation(res.data.parseMedicationLabel.data);
+        } else {
+          setShowFallbackOptions(true);
+        }
+      } else {
+        setShowFallbackOptions(true);
+      }
+    } catch (err) {
+      console.error('Single photo scanning error:', err);
+      setShowFallbackOptions(true);
+    } finally {
+      if (result) {
+        await cleanupAlternativeScanFiles(result);
+      } else {
+        await FileSystem.deleteAsync(imageUri, { idempotent: true }).catch(() => {});
+      }
+      setIsProcessing(false);
+      setProcessingMedia(null);
+    }
+  };
+
+  const handleSinglePhotoCancel = () => {
+    setShowSinglePhotoCapture(false);
+    setShowFallbackOptions(true);
+  };
+
   useEffect(() => {
     if (method) {
       if (method === 'photo_stitching') {
         setShowPanoramaCapture(true);
+      } else if (method === 'single_photo') {
+        setShowSinglePhotoCapture(true);
       } else {
         handleAlternativeScan(method);
       }
@@ -660,6 +712,15 @@ console.log("Texts From clyindericalUnrap: =====================================
           style={styles.permissionButton}
         />
       </SafeAreaView>
+    );
+  }
+
+  if (showSinglePhotoCapture) {
+    return (
+      <SinglePhotoCapture
+        onCaptureComplete={handleSinglePhotoResult}
+        onCancel={handleSinglePhotoCancel}
+      />
     );
   }
 

--- a/components/SinglePhotoCapture.tsx
+++ b/components/SinglePhotoCapture.tsx
@@ -1,0 +1,51 @@
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { CameraType } from 'expo-image-picker';
+import { useRef } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import CameraControls from './CameraControls';
+
+interface Props {
+  onCaptureComplete: (imageUri: string) => void;
+  onCancel: () => void;
+}
+
+export default function SinglePhotoCapture({ onCaptureComplete, onCancel }: Props) {
+  const [permission, requestPermission] = useCameraPermissions();
+  const cameraRef = useRef<CameraView | null>(null);
+
+  if (!permission?.granted) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.text}>Camera permission is required.</Text>
+        <TouchableOpacity onPress={requestPermission}>
+          <Text style={[styles.text, { color: '#4da3ff' }]}>Grant Permission</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  const handleCapture = async () => {
+    if (!cameraRef.current) return;
+    try {
+      const photo = await cameraRef.current.takePictureAsync({ quality: 0.8 });
+      onCaptureComplete(photo.uri);
+    } catch (e) {
+      console.warn('Capture failed', e);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <CameraView ref={cameraRef} style={styles.camera} facing={CameraType.back} />
+      <CameraControls onClose={onCancel} onCapture={handleCapture} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  camera: { flex: 1 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#000' },
+  text: { color: '#fff', fontSize: 16 },
+});
+

--- a/utils/scanners/singlePhotoScanner.ts
+++ b/utils/scanners/singlePhotoScanner.ts
@@ -36,22 +36,25 @@ export class SinglePhotoScanner {
     return imageUri;
   }
 
-  async performSinglePhotoScan(): Promise<AlternativeScanResult> {
+  async performSinglePhotoScan(imageUri?: string): Promise<AlternativeScanResult> {
     try {
-      const imageUri = await this.captureSinglePhoto();
-      const enhancedUri = await this.enhanceImageForOCR(imageUri);
+      const captureUri = imageUri ?? (await this.captureSinglePhoto());
+      const enhancedUri = await this.enhanceImageForOCR(captureUri);
 
       const ocrResult = await ExpoMlkitOcr.recognizeText(enhancedUri);
       const extractedText = ocrResult.text.trim();
 
-      const confidence = this.calculateSinglePhotoConfidence(extractedText, ocrResult);
+      const confidence = this.calculateSinglePhotoConfidence(
+        extractedText,
+        ocrResult
+      );
 
       return {
         success: true,
         extractedText,
         confidence,
         method: 'single_photo',
-        images: [imageUri, enhancedUri],
+        images: [captureUri, enhancedUri],
       };
     } catch (error) {
       return {
@@ -59,7 +62,7 @@ export class SinglePhotoScanner {
         extractedText: '',
         confidence: 0,
         method: 'single_photo',
-        images: [],
+        images: imageUri ? [imageUri] : [],
         error: error instanceof Error ? error.message : 'Unknown error',
       };
     }


### PR DESCRIPTION
## Summary
- add reusable camera-based single photo capture component
- update single photo scanner to process externally captured images
- integrate single photo capture into medication scan flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0301ec3e083248752d0df636ae527