### PR TITLE
Use pressable microphone button for voice input

### DIFF
--- a/app/medication/voice.tsx
+++ b/app/medication/voice.tsx
@@ -4,8 +4,18 @@ import { useMicrophonePermissions } from "expo-camera";
 import { useRouter } from "expo-router";
 import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from "expo-speech-recognition";
 import { useState } from "react";
-import { ActivityIndicator, Alert, SafeAreaView, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
-import Button from "../../components/ui/Button";
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextStyle,
+  View,
+  ViewStyle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { handleParsedText } from "../../services/medicationService";
 import { useMedicationStore } from "../../store/medication-store";
 
@@ -72,17 +82,26 @@ export default function MedicationVoiceScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
-        {isListening ? (
-          <>
-            <View style={styles.indicator}>
-              <ActivityIndicator color={Colors[colorScheme].tint} />
-              <Text style={styles.indicatorText}>Listening...</Text>
-            </View>
-            <Button title="Stop" onPress={stopListening} style={styles.button} />
-          </>
-        ) : (
-          <Button title="Start" onPress={startListening} style={styles.button} />
+        {isListening && (
+          <View style={styles.indicator}>
+            <ActivityIndicator color={Colors[colorScheme].tint} />
+            <Text style={styles.indicatorText}>Listening...</Text>
+          </View>
         )}
+        <Pressable
+          style={({ pressed }) => [
+            styles.micButton,
+            pressed && { opacity: 0.7 },
+          ]}
+          onPressIn={startListening}
+          onPressOut={stopListening}
+        >
+          <Ionicons
+            name="mic"
+            size={32}
+            color={Colors[colorScheme].foreground}
+          />
+        </Pressable>
       </View>
     </SafeAreaView>
   );
@@ -95,7 +114,7 @@ type Styles = {
   indicator: ViewStyle;
   indicatorText: TextStyle;
   message: TextStyle;
-  button: ViewStyle;
+  micButton: ViewStyle;
 };
 
 function createStyles(colorScheme: "light" | "dark") {
@@ -123,8 +142,13 @@ function createStyles(colorScheme: "light" | "dark") {
       color: Colors[colorScheme].text,
       fontSize: 16,
     },
-    button: {
-      width: 200,
+    micButton: {
+      width: 80,
+      height: 80,
+      borderRadius: 40,
+      backgroundColor: Colors[colorScheme].tint,
+      justifyContent: "center",
+      alignItems: "center",
     },
   });
 }


### PR DESCRIPTION
## Summary
- replace start/stop buttons with a pressable microphone button
- start speech recognition on press and stop on release

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a036e10b50832485540f4a1b772dad