### PR TITLE
Add animated recording indicator

### DIFF
--- a/app/medication/voice.tsx
+++ b/app/medication/voice.tsx
@@ -4,7 +4,8 @@ import { useMicrophonePermissions } from "expo-camera";
 import { useRouter } from "expo-router";
 import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from "expo-speech-recognition";
 import { useState } from "react";
-import { ActivityIndicator, Alert, SafeAreaView, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
+import { Alert, SafeAreaView, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
+import RecordingIndicator from "../../components/RecordingIndicator";
 import Button from "../../components/ui/Button";
 import { handleParsedText } from "../../services/medicationService";
 import { useMedicationStore } from "../../store/medication-store";
@@ -75,7 +76,7 @@ export default function MedicationVoiceScreen() {
         {isListening ? (
           <>
             <View style={styles.indicator}>
-              <ActivityIndicator color={Colors[colorScheme].tint} />
+              <RecordingIndicator active={isListening} />
               <Text style={styles.indicatorText}>Listening...</Text>
             </View>
             <Button title="Stop" onPress={stopListening} style={styles.button} />

--- a/components/RecordingIndicator.tsx
+++ b/components/RecordingIndicator.tsx
@@ -1,0 +1,57 @@
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { useEffect, useRef } from "react";
+import { Animated, StyleSheet } from "react-native";
+import { Colors } from "@/constants/Colors";
+
+interface RecordingIndicatorProps {
+  active: boolean;
+  size?: number;
+}
+
+export default function RecordingIndicator({ active, size = 12 }: RecordingIndicatorProps) {
+  const colorScheme = useColorScheme() ?? "light";
+  const scale = useRef(new Animated.Value(1)).current;
+  const animation = useRef<Animated.CompositeAnimation>();
+
+  useEffect(() => {
+    if (active) {
+      animation.current = Animated.loop(
+        Animated.sequence([
+          Animated.timing(scale, {
+            toValue: 1.4,
+            duration: 600,
+            useNativeDriver: true,
+          }),
+          Animated.timing(scale, {
+            toValue: 1,
+            duration: 600,
+            useNativeDriver: true,
+          }),
+        ])
+      );
+      animation.current.start();
+    } else {
+      animation.current?.stop();
+      scale.setValue(1);
+    }
+
+    return () => {
+      animation.current?.stop();
+    };
+  }, [active, scale]);
+
+  const styles = createStyles(colorScheme, size);
+
+  return <Animated.View style={[styles.dot, { transform: [{ scale }] }]} />;
+}
+
+function createStyles(colorScheme: "light" | "dark", size: number) {
+  return StyleSheet.create({
+    dot: {
+      width: size,
+      height: size,
+      borderRadius: size / 2,
+      backgroundColor: Colors[colorScheme].tint,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable `RecordingIndicator` component with pulsing animation
- replace ActivityIndicator in voice screen with new indicator reacting to listening state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a036e25c208324a8509a297793ae97