### PR TITLE
Handle speech recognition errors in voice input

### DIFF
--- a/app/medication/voice.tsx
+++ b/app/medication/voice.tsx
@@ -159,9 +159,18 @@ export default function MedicationVoiceScreen() {
     }
   });
 
-  // Stop the listening indicator on errors
-  useSpeechRecognitionEvent("error", () => {
+  // Stop the listening indicator on errors and terminate recognition
+  useSpeechRecognitionEvent("error", async (event) => {
     setIsListening(false);
+    try {
+      await ExpoSpeechRecognitionModule.stop();
+    } catch (err) {
+      console.error("Speech recognition stop error:", err);
+    }
+    Alert.alert(
+      "Speech recognition error",
+      (event as any)?.error?.message || "Please try again."
+    );
   });
 
   /**


### PR DESCRIPTION
## Summary
- Stop speech recognition module when an error occurs and show alert prompting retry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfc6dcc08324a55dcee894452ae3