### PR TITLE
Separate voice cleanup effects

### DIFF
--- a/app/medication/voice.tsx
+++ b/app/medication/voice.tsx
@@ -240,14 +240,19 @@ export default function MedicationVoiceScreen() {
     setHasPlayed(false);
   };
 
-  // Clean up the sound and speech recognition module when the
-  // component is unmounted or when the sound instance changes.
+  // Unload any previous sound when a new `Audio.Sound` instance is set.
   useEffect(() => {
     return () => {
       sound?.unloadAsync();
-      ExpoSpeechRecognitionModule.stop();
     };
   }, [sound]);
+
+  // Stop speech recognition when the component unmounts.
+  useEffect(() => {
+    return () => {
+      ExpoSpeechRecognitionModule.stop();
+    };
+  }, []);
 
   /**
    * Render the UI. The layout adjusts based on whether the user is


### PR DESCRIPTION
## Summary
- split cleanup effect into two hooks to unload sounds and stop speech recognition separately

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0cfc78b30832492225ff35609132c